### PR TITLE
User mute expiration

### DIFF
--- a/stream_chat/client.py
+++ b/stream_chat/client.py
@@ -165,8 +165,7 @@ class StreamChat(object):
         :param options: additional mute options
         :return:
         """
-        data = dict(target_id=target_id, user_id=user_id)
-        data.update(options)
+        data = dict(target_id=target_id, user_id=user_id, **options)
         return self.post("moderation/mute", data=data)
 
     def unmute_user(self, target_id, user_id):

--- a/stream_chat/client.py
+++ b/stream_chat/client.py
@@ -156,15 +156,17 @@ class StreamChat(object):
         data.update(options)
         return self.post("moderation/unflag", data=data)
 
-    def mute_user(self, target_id, user_id):
+    def mute_user(self, target_id, user_id, **options):
         """
         Create a mute
 
         :param target_id: the user getting muted
         :param user_id: the user muting the target
+        :param options: additional mute options
         :return:
         """
         data = dict(target_id=target_id, user_id=user_id)
+        data.update(options)
         return self.post("moderation/mute", data=data)
 
     def unmute_user(self, target_id, user_id):

--- a/stream_chat/tests/test_client.py
+++ b/stream_chat/tests/test_client.py
@@ -10,6 +10,15 @@ class TestClient(object):
     def test_mute_user(self, client, random_users):
         response = client.mute_user(random_users[0]["id"], random_users[1]["id"])
         assert "mute" in response
+        assert "expires" not in response["mute"]
+        assert response["mute"]["target"]["id"] == random_users[0]["id"]
+        assert response["mute"]["user"]["id"] == random_users[1]["id"]
+        client.unmute_user(random_users[0]["id"], random_users[1]["id"])
+
+    def test_mute_user_with_timeout(self, client, random_users):
+        response = client.mute_user(random_users[0]["id"], random_users[1]["id"], timeout=10)
+        assert "mute" in response
+        assert "expires" in response["mute"]
         assert response["mute"]["target"]["id"] == random_users[0]["id"]
         assert response["mute"]["user"]["id"] == random_users[1]["id"]
         client.unmute_user(random_users[0]["id"], random_users[1]["id"])

--- a/stream_chat/tests/test_client.py
+++ b/stream_chat/tests/test_client.py
@@ -16,7 +16,9 @@ class TestClient(object):
         client.unmute_user(random_users[0]["id"], random_users[1]["id"])
 
     def test_mute_user_with_timeout(self, client, random_users):
-        response = client.mute_user(random_users[0]["id"], random_users[1]["id"], timeout=10)
+        response = client.mute_user(
+            random_users[0]["id"], random_users[1]["id"], timeout=10
+        )
         assert "mute" in response
         assert "expires" in response["mute"]
         assert response["mute"]["target"]["id"] == random_users[0]["id"]


### PR DESCRIPTION
In order to support user mute expiration, I've added an `options` keyword argument to the `mute_user` api method. When a `timeout` option given, an expiry time on the mute is set in the backend.