### PR TITLE
feature/5/python-api-docs

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/_sources/modules.rst
+++ b/docs/_sources/modules.rst
@@ -1,0 +1,7 @@
+stream_chat
+===========
+
+.. toctree::
+   :maxdepth: 4
+
+   stream_chat

--- a/docs/_sources/stream_chat.rst
+++ b/docs/_sources/stream_chat.rst
@@ -1,0 +1,45 @@
+stream\_chat package
+====================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   stream_chat.tests
+
+Submodules
+----------
+
+stream\_chat.channel module
+---------------------------
+
+.. automodule:: stream_chat.channel
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+stream\_chat.client module
+--------------------------
+
+.. automodule:: stream_chat.client
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+stream\_chat.exceptions module
+------------------------------
+
+.. automodule:: stream_chat.exceptions
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: stream_chat
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/_sources/stream_chat.tests.rst
+++ b/docs/_sources/stream_chat.tests.rst
@@ -1,0 +1,37 @@
+stream\_chat.tests package
+==========================
+
+Submodules
+----------
+
+stream\_chat.tests.conftest module
+----------------------------------
+
+.. automodule:: stream_chat.tests.conftest
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+stream\_chat.tests.test\_channel module
+---------------------------------------
+
+.. automodule:: stream_chat.tests.test_channel
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+stream\_chat.tests.test\_client module
+--------------------------------------
+
+.. automodule:: stream_chat.tests.test_client
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: stream_chat.tests
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,14 +10,14 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import os
+import sys
+sys.path.insert(0, os.path.abspath('..'))
 
 
 # -- Project information -----------------------------------------------------
 
-project = 'stream-chat-python'
+project = 'stream_chat'
 copyright = '2020, Stream'
 author = 'Stream'
 
@@ -30,8 +30,7 @@ release = 'v1.4.0'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = [
-]
+extensions = ['sphinx.ext.autodoc']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -47,7 +46,7 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+html_theme = 'sphinx_rtd_theme'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,55 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'stream-chat-python'
+copyright = '2020, Stream'
+author = 'Stream'
+
+# The full version, including alpha/beta/rc tags
+release = 'v1.4.0'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'alabaster'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,20 @@
+.. stream-chat-python documentation master file, created by
+   sphinx-quickstart on Mon Aug 24 11:13:35 2020.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to stream-chat-python's documentation!
+==============================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,9 +1,4 @@
-.. stream-chat-python documentation master file, created by
-   sphinx-quickstart on Mon Aug 24 11:13:35 2020.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-
-Welcome to stream-chat-python's documentation!
+stream-chat-python documentation
 ==============================================
 
 .. toctree::

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+Sphinx==3.2.1
+sphinx-rtd-theme==0.5.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,4 @@
 Sphinx==3.2.1
 sphinx-rtd-theme==0.5.0
+jwt==1.0.0
+pytest==6.0.1


### PR DESCRIPTION
# Submit a pull request

## CLA

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [X] The code changes follow best practices
- [X] Code changes are tested (add some information if not applicable)

## Description of the pull request
This is an attempt to work toward fixing #5, where the actual python implementation lacks documentation.

This PR has a working example docs here: https://stream-chat-python-docs.readthedocs.io/en/latest/_sources/stream_chat.html#subpackages

This was my first time building for sphinx / rtd. 

It is likely someone more familiar with sphinx api doc gen could make the landing page for the docs be simply the stream_chat package.

Edit:

Upon further review, it looks like this is not catching the actual module.  I think a minor tweak would get this working.