### PR TITLE
[CHAT-1319] Added ability to provide sort options as list to guarantee field order

### DIFF
--- a/stream_chat/channel.py
+++ b/stream_chat/channel.py
@@ -107,7 +107,7 @@ class Channel(object):
 
         eg.
         channel.query_members(filter_conditions={"name": "tommaso"},
-                              sort=[{"field": "created_at", "direction": -1}],
+                              sort=[{"created_at": -1}, {"updated_at": 1}],
                               offset=0,
                               limit=10)
         """
@@ -116,7 +116,7 @@ class Channel(object):
             "id": self.id,
             "type": self.channel_type,
             "filter_conditions": filter_conditions,
-            "sort": sort or [],
+            "sort": self.client.normalize_sort(sort),
             **options,
         }
         response = self.client.get("members", params={"payload": json.dumps(payload)})

--- a/stream_chat/client.py
+++ b/stream_chat/client.py
@@ -78,7 +78,7 @@ class StreamChat(object):
 
     def normalize_sort(self, sort=None):
         sort_fields = []
-        if isinstance(sort, collections.Mapping):
+        if isinstance(sort, collections.abc.Mapping):
             sort = [sort]
         if isinstance(sort, list):
             for item in sort:

--- a/stream_chat/client.py
+++ b/stream_chat/client.py
@@ -1,3 +1,4 @@
+import collections
 from urllib.parse import urlparse
 import hmac
 import hashlib
@@ -74,6 +75,19 @@ class StreamChat(object):
             timeout=self.timeout,
         )
         return self._parse_response(response)
+
+    def normalize_sort(self, sort=None):
+        sort_fields = []
+        if isinstance(sort, collections.Mapping):
+            sort = [sort]
+        if isinstance(sort, list):
+            for item in sort:
+                if 'field' in item and 'direction' in item:
+                    sort_fields.append(item)
+                else:
+                    for k, v in item.items():
+                        sort_fields.append({"field": k, "direction": v})
+        return sort_fields
 
     def put(self, relative_url, params=None, data=None):
         return self._make_request(self.session.put, relative_url, params, data)
@@ -189,20 +203,14 @@ class StreamChat(object):
         return self.get("messages/{}".format(message_id))
 
     def query_users(self, filter_conditions, sort=None, **options):
-        sort_fields = []
-        if sort is not None:
-            sort_fields = [{"field": k, "direction": v} for k, v in sort.items()]
         params = options.copy()
-        params.update({"filter_conditions": filter_conditions, "sort": sort_fields})
+        params.update({"filter_conditions": filter_conditions, "sort": self.normalize_sort(sort)})
         return self.get("users", params={"payload": json.dumps(params)})
 
     def query_channels(self, filter_conditions, sort=None, **options):
         params = {"state": True, "watch": False, "presence": False}
-        sort_fields = []
-        if sort is not None:
-            sort_fields = [{"field": k, "direction": v} for k, v in sort.items()]
         params.update(options)
-        params.update({"filter_conditions": filter_conditions, "sort": sort_fields})
+        params.update({"filter_conditions": filter_conditions, "sort": self.normalize_sort(sort)})
         return self.get("channels", params={"payload": json.dumps(params)})
 
     def create_channel_type(self, data):

--- a/stream_chat/client.py
+++ b/stream_chat/client.py
@@ -82,7 +82,7 @@ class StreamChat(object):
             sort = [sort]
         if isinstance(sort, list):
             for item in sort:
-                if 'field' in item and 'direction' in item:
+                if "field" in item and "direction" in item:
                     sort_fields.append(item)
                 else:
                     for k, v in item.items():
@@ -204,13 +204,17 @@ class StreamChat(object):
 
     def query_users(self, filter_conditions, sort=None, **options):
         params = options.copy()
-        params.update({"filter_conditions": filter_conditions, "sort": self.normalize_sort(sort)})
+        params.update(
+            {"filter_conditions": filter_conditions, "sort": self.normalize_sort(sort)}
+        )
         return self.get("users", params={"payload": json.dumps(params)})
 
     def query_channels(self, filter_conditions, sort=None, **options):
         params = {"state": True, "watch": False, "presence": False}
         params.update(options)
-        params.update({"filter_conditions": filter_conditions, "sort": self.normalize_sort(sort)})
+        params.update(
+            {"filter_conditions": filter_conditions, "sort": self.normalize_sort(sort)}
+        )
         return self.get("channels", params={"payload": json.dumps(params)})
 
     def create_channel_type(self, data):

--- a/stream_chat/tests/conftest.py
+++ b/stream_chat/tests/conftest.py
@@ -76,7 +76,9 @@ def command(client):
         dict(name=str(uuid.uuid4()), description="My command")
     )
 
-    return response["command"]
+    yield response["command"]
+
+    client.delete_command(response["command"]["name"])
 
 
 @pytest.fixture(scope="module")

--- a/stream_chat/tests/test_client.py
+++ b/stream_chat/tests/test_client.py
@@ -52,7 +52,6 @@ class TestClient(object):
         assert "commands" in response
         assert response["commands"] == ["ban", "unban"]
 
-
     def test_get_command(self, client, command):
         response = client.get_command(command["name"])
         assert command["name"] == response["name"]
@@ -243,10 +242,15 @@ class TestClient(object):
         client.delete_blocklist("Foo")
 
     def test_normalize_sort(self, client):
-        expected = [{"field": "field1", "direction": 1}, {"field": "field2", "direction": -1}]
+        expected = [
+            {"field": "field1", "direction": 1},
+            {"field": "field2", "direction": -1},
+        ]
         actual = client.normalize_sort([{"field1": 1}, {"field2": -1}])
         assert actual == expected
-        actual = client.normalize_sort([{"field": "field1", "direction": 1}, {"field": "field2", "direction": -1}])
+        actual = client.normalize_sort(
+            [{"field": "field1", "direction": 1}, {"field": "field2", "direction": -1}]
+        )
         assert actual == expected
         actual = client.normalize_sort({"field1": 1})
         assert actual == [{"field": "field1", "direction": 1}]

--- a/stream_chat/tests/test_client.py
+++ b/stream_chat/tests/test_client.py
@@ -52,6 +52,7 @@ class TestClient(object):
         assert "commands" in response
         assert response["commands"] == ["ban", "unban"]
 
+
     def test_get_command(self, client, command):
         response = client.get_command(command["name"])
         assert command["name"] == response["name"]
@@ -60,11 +61,6 @@ class TestClient(object):
         response = client.update_command(command["name"], description="My new command")
         assert "command" in response
         assert "My new command" == response["command"]["description"]
-
-    def test_delete_command(self, client, command):
-        response = client.delete_command(command["name"])
-        with pytest.raises(StreamAPIException):
-            client.get_command(command["name"])
 
     def test_list_commands(self, client):
         response = client.list_commands()

--- a/stream_chat/tests/test_client.py
+++ b/stream_chat/tests/test_client.py
@@ -1,5 +1,8 @@
+from operator import itemgetter
+
 import jwt
 import pytest
+import sys
 import uuid
 from stream_chat import StreamChat
 from stream_chat.exceptions import StreamAPIException
@@ -7,6 +10,27 @@ from stream_chat.exceptions import StreamAPIException
 
 @pytest.mark.incremental
 class TestClient(object):
+    def test_normalize_sort(self, client):
+        expected = [
+            {"field": "field1", "direction": 1},
+            {"field": "field2", "direction": -1},
+        ]
+        actual = client.normalize_sort([{"field1": 1}, {"field2": -1}])
+        assert actual == expected
+        actual = client.normalize_sort(
+            [{"field": "field1", "direction": 1}, {"field": "field2", "direction": -1}]
+        )
+        assert actual == expected
+        actual = client.normalize_sort({"field1": 1})
+        assert actual == [{"field": "field1", "direction": 1}]
+        # The following example is not recommended because the order of the fields is not guaranteed in Python < 3.7
+        actual = client.normalize_sort({"field1": 1, "field2": -1})
+        if sys.version_info >= (3, 7):
+            assert actual == expected
+        else:
+            # Compare elements regardless of the order
+            assert sorted(actual, key=itemgetter("field")) == expected
+
     def test_mute_user(self, client, random_users):
         response = client.mute_user(random_users[0]["id"], random_users[1]["id"])
         assert "mute" in response
@@ -240,20 +264,3 @@ class TestClient(object):
 
     def test_delete_blocklist(self, client):
         client.delete_blocklist("Foo")
-
-    def test_normalize_sort(self, client):
-        expected = [
-            {"field": "field1", "direction": 1},
-            {"field": "field2", "direction": -1},
-        ]
-        actual = client.normalize_sort([{"field1": 1}, {"field2": -1}])
-        assert actual == expected
-        actual = client.normalize_sort(
-            [{"field": "field1", "direction": 1}, {"field": "field2", "direction": -1}]
-        )
-        assert actual == expected
-        actual = client.normalize_sort({"field1": 1})
-        assert actual == [{"field": "field1", "direction": 1}]
-        # The following example is not recommended because the order of the fields is not guaranteed in Python < 3.7
-        actual = client.normalize_sort({"field1": 1, "field2": -1})
-        assert actual == expected

--- a/stream_chat/tests/test_client.py
+++ b/stream_chat/tests/test_client.py
@@ -254,3 +254,6 @@ class TestClient(object):
         assert actual == expected
         actual = client.normalize_sort({"field1": 1})
         assert actual == [{"field": "field1", "direction": 1}]
+        # The following example is not recommended because the order of the fields is not guaranteed in Python < 3.7
+        actual = client.normalize_sort({"field1": 1, "field2": -1})
+        assert actual == expected

--- a/stream_chat/tests/test_client.py
+++ b/stream_chat/tests/test_client.py
@@ -245,3 +245,12 @@ class TestClient(object):
 
     def test_delete_blocklist(self, client):
         client.delete_blocklist("Foo")
+
+    def test_normalize_sort(self, client):
+        expected = [{"field": "field1", "direction": 1}, {"field": "field2", "direction": -1}]
+        actual = client.normalize_sort([{"field1": 1}, {"field2": -1}])
+        assert actual == expected
+        actual = client.normalize_sort([{"field": "field1", "direction": 1}, {"field": "field2", "direction": -1}])
+        assert actual == expected
+        actual = client.normalize_sort({"field1": 1})
+        assert actual == [{"field": "field1", "direction": 1}]


### PR DESCRIPTION
This PR fixes inconsistency of `sort` parameter of the query_members method and adds new ability to provide sort options as list to guarantee field order.

[Dict field order is only guaranteed since Python 3.7](https://stackoverflow.com/a/40007169/1039202)