### PR TITLE
added check sqs endpoint to sdk

### DIFF
--- a/stream_chat/async_chat/client.py
+++ b/stream_chat/async_chat/client.py
@@ -346,6 +346,20 @@ class StreamChatAsync(StreamChatInterface):
         """
         return await self.delete(f"blocklists/{name}")
 
+    async def check_sqs(self, sqs_key=None, sqs_secret=None, sqs_url=None):
+        """
+        Check SQS Push settings
+
+        When no parameters are given, the current SQS app settings are used
+
+        :param sqs_key: AWS access key
+        :param sqs_secret: AWS secret key
+        :param sqs_url: URL to SQS queue
+        :return:
+        """
+        data = {"sqs_key": sqs_key, "sqs_secret": sqs_secret, "sqs_url": sqs_url}
+        return await self.post("check_sqs", data=data)
+
     async def close(self):
         await self.session.close()
 

--- a/stream_chat/base/client.py
+++ b/stream_chat/base/client.py
@@ -316,3 +316,17 @@ class StreamChatInterface(abc.ABC):
         :return:
         """
         pass
+
+    @abc.abstractmethod
+    async def check_sqs(self, sqs_key=None, sqs_secret=None, sqs_url=None):
+        """
+        Check SQS Push settings
+
+        When no parameters are given, the current SQS app settings are used
+
+        :param sqs_key: AWS access key
+        :param sqs_secret: AWS secret key
+        :param sqs_url: URL to SQS queue
+        :return:
+        """
+        pass

--- a/stream_chat/client.py
+++ b/stream_chat/client.py
@@ -333,3 +333,17 @@ class StreamChat(StreamChatInterface):
         :return:
         """
         return self.delete(f"blocklists/{name}")
+
+    def check_sqs(self, sqs_key=None, sqs_secret=None, sqs_url=None):
+        """
+        Check SQS Push settings
+
+        When no parameters are given, the current SQS app settings are used
+
+        :param sqs_key: AWS access key
+        :param sqs_secret: AWS secret key
+        :param sqs_url: URL to SQS queue
+        :return:
+        """
+        data = {"sqs_key": sqs_key, "sqs_secret": sqs_secret, "sqs_url": sqs_url}
+        return self.post("check_sqs", data=data)

--- a/stream_chat/tests/async_chat/test_client.py
+++ b/stream_chat/tests/async_chat/test_client.py
@@ -324,3 +324,9 @@ class TestClient(object):
     @pytest.mark.asyncio
     async def test_delete_blocklist(self, event_loop, client):
         await client.delete_blocklist("Foo")
+
+    @pytest.mark.asyncio
+    async def test_check_sqs(self, client):
+        response = await client.check_sqs("key", "secret", "https://foo.com/bar")
+        assert response["status"] == "error"
+        assert "invalid SQS url" in response["error"]

--- a/stream_chat/tests/test_client.py
+++ b/stream_chat/tests/test_client.py
@@ -265,3 +265,8 @@ class TestClient(object):
 
     def test_delete_blocklist(self, client):
         client.delete_blocklist("Foo")
+
+    def test_check_sqs(self, client):
+        response = client.check_sqs("key", "secret", "https://foo.com/bar")
+        assert response["status"] == "error"
+        assert "invalid SQS url" in response["error"]


### PR DESCRIPTION
added sync and async endpoint for `check_sqs`, an endpoint to be used to verify credentials/settings for SQS push.

🚨  This depends on a (currently) unreleased backend feature, hence the failing tests. To be merged afterward.

related ruby SDK changes: https://github.com/GetStream/stream-chat-ruby/pull/32