### PR TITLE
Release 3.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Jul 5, 2021 - 3.11.0
+
+- Update existing permission related API (/roles and /permissions endpoints) 
+
 ## Jul 2, 2021 - 3.10.0
 
 - Add support for campaign API (early alpha, can change)

--- a/stream_chat/__pkg__.py
+++ b/stream_chat/__pkg__.py
@@ -1,6 +1,6 @@
 __author__ = "Tommaso Barbugli"
 __copyright__ = "Copyright 2019-2021, Stream.io, Inc"
-__version__ = "3.10.0"
+__version__ = "3.11.0"
 __maintainer__ = "Tommaso Barbugli"
 __email__ = "support@getstream.io"
 __status__ = "Production"


### PR DESCRIPTION
## Jul 5, 2021 - 3.11.0

- Update existing permission related API (/roles and /permissions endpoints) 