### PR TITLE
Add export_channel, get_export_channel_status

### DIFF
--- a/stream_chat/async_chat/client.py
+++ b/stream_chat/async_chat/client.py
@@ -581,6 +581,55 @@ class StreamChatAsync(StreamChatInterface):
             )
         await self.update_users_partial(updates)
 
+    async def export_channel(self, channel_id: str, channel_type: str, messages_since: str = None,
+                             messages_until=None):
+        """
+        Requests a channel export
+        :param channel_id: channel_id of channel which needs to be exported
+        :param channel_type: channel_type of channel which needs to be exported
+        :param messages_since: RFC-3339 string or datetime to filter messages since that time, optional
+        :param messages_until: RFC-3339 string or datetime to filter messages until that time, optional
+        :type channel_id: str
+        :type channel_type: str
+        :type messages_since: Union[str, datetime.datetime]
+        :type messages_until: Union[str, datetime.datetime]
+        """
+        if isinstance(messages_since, datetime.datetime):
+            messages_since = messages_since.isoformat()
+        if isinstance(messages_until, datetime.datetime):
+            messages_until = messages_until.isoformat()
+
+        return await self.export_channels(
+            [
+                {
+                    "id": channel_id,
+                    "type": channel_type,
+                    "messages_since": messages_since,
+                    "messages_until": messages_until
+                }
+            ]
+        )
+
+    async def export_channels(self, channels_data: list):
+        """
+        Requests a channels export
+        :param channels_data: list of channel's data which need to be exported with keys:
+        - `channel_id`: str
+        - `channel_type`: str
+        - `messages_since` (optional, nullable): str
+        - `messages_until` (optional, nullable): str
+        :type channels_data: List[Dict[str, str]]
+        """
+        return await self.post("export_channels", data={"channels": channels_data})
+
+    async def get_export_channel_status(self, task_id: str):
+        """
+        Retrieves status of export
+        :param task_id: task_id of task which status needs to be retrieved
+        :type task_id: str
+        """
+        return await self.get(f"export_channels/{task_id}")
+
     async def close(self):
         await self.session.close()
 

--- a/stream_chat/base/client.py
+++ b/stream_chat/base/client.py
@@ -549,3 +549,25 @@ class StreamChatInterface(abc.ABC):
         Revoke tokens for users issued since
         """
         pass
+
+    @abc.abstractmethod
+    def export_channel(self, channel_id: str, channel_type: str, messages_since: str = None,
+                       messages_until=None):
+        """
+        Requests a channel export
+        """
+        pass
+
+    @abc.abstractmethod
+    def export_channels(self, channels_data: list):
+        """
+        Requests a channels export
+        """
+        pass
+
+    @abc.abstractmethod
+    def get_export_channel_status(self, task_id: str):
+        """
+        Retrieves status of export
+        """
+        pass

--- a/stream_chat/client.py
+++ b/stream_chat/client.py
@@ -568,3 +568,52 @@ class StreamChat(StreamChatInterface):
                 {"id": user_id, "set": {"revoke_tokens_issued_before": before}}
             )
         self.update_users_partial(updates)
+
+    def export_channel(self, channel_id: str, channel_type: str, messages_since: str = None,
+                       messages_until=None):
+        """
+        Requests a channel export
+        :param channel_id: channel_id of channel which needs to be exported
+        :param channel_type: channel_type of channel which needs to be exported
+        :param messages_since: RFC-3339 string or datetime to filter messages since that time, optional
+        :param messages_until: RFC-3339 string or datetime to filter messages until that time, optional
+        :type channel_id: str
+        :type channel_type: str
+        :type messages_since: Union[str, datetime.datetime]
+        :type messages_until: Union[str, datetime.datetime]
+        """
+        if isinstance(messages_since, datetime.datetime):
+            messages_since = messages_since.isoformat()
+        if isinstance(messages_until, datetime.datetime):
+            messages_until = messages_until.isoformat()
+
+        return self.export_channels(
+            [
+                {
+                    "id": channel_id,
+                    "type": channel_type,
+                    "messages_since": messages_since,
+                    "messages_until": messages_until
+                }
+            ]
+        )
+
+    def export_channels(self, channels_data: list):
+        """
+        Requests a channels export
+        :param channels_data: list of channel's data which need to be exported with keys:
+        - `channel_id`: str
+        - `channel_type`: str
+        - `messages_since` (optional, nullable): str
+        - `messages_until` (optional, nullable): str
+        :type channels_data: List[Dict[str, str]]
+        """
+        return self.post("export_channels", data={"channels": channels_data})
+
+    def get_export_channel_status(self, task_id: str):
+        """
+        Retrieves status of export
+        :param task_id: task_id of task which status needs to be retrieved
+        :type task_id: str
+        """
+        return self.get(f"export_channels/{task_id}")


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request

Adds calls to get stream API similar to [get-stream-js](https://github.com/GetStream/stream-chat-js/) for:
- requesting channel export
- fetching channel export status

Implemented as:
```python
def export_channel(self, channel_id: str, channel_type: str, messages_since: str = None,
                       messages_until=None):
    """
    Requests a channel export
    """
...

def export_channels(self, channels_data: list):
    """
    Requests a channels export
    """
...

def get_export_channel_status(self, task_id: str):
    """
    Retrieves status of export
    """
...
```
Example usage:
```python
>>> from stream_chat import StreamChat
>>> client = StreamChat(api_key=os.environ.get('STREAM_API_KEY', None), api_secret=os.environ.get('STREAM_API_SECRET', None))
>>> response = client.export_channel(my_channel_id, my_channel_type)
>>> response

{'task_id': ..., 'duration': '18.82ms'}

>>> export = client.get_export_channel_status(response['task_id'])
>>> export

{'task_id': ..., 'status': 'completed', 'created_at': ..., 'updated_at': ..., 'duration': ..., 'result': {'url': ...}, 'error': {'type': '', 'description': None}}

```