### PR TITLE
Tune session timeouts

### DIFF
--- a/stream_chat/async_chat/client.py
+++ b/stream_chat/async_chat/client.py
@@ -30,7 +30,9 @@ class StreamChatAsync(StreamChatInterface):
         super().__init__(
             api_key=api_key, api_secret=api_secret, timeout=timeout, **options
         )
-        self.session = aiohttp.ClientSession()
+        self.session = aiohttp.ClientSession(
+            connector=aiohttp.TCPConnector(keepalive_timeout=3.9)
+        )
 
     async def _parse_response(self, response):
         text = await response.text()

--- a/stream_chat/client.py
+++ b/stream_chat/client.py
@@ -29,7 +29,10 @@ class StreamChat(StreamChatInterface):
         super().__init__(
             api_key=api_key, api_secret=api_secret, timeout=timeout, **options
         )
-        self.session = requests.Session()
+        s = requests.Session()
+        s.mount("http://", requests.adapters.HTTPAdapter(max_retries=1))
+        s.mount("https://", requests.adapters.HTTPAdapter(max_retries=1))
+        self.session = s
 
     def _parse_response(self, response):
         try:


### PR DESCRIPTION
* async client is set to less than server max idle
* sync client retries on bad conn (dns lookup, idle timeout, etc.), never on request