### PR TITLE
[CHAT-2260] Add condition to custom permissions tests

### DIFF
--- a/stream_chat/tests/async_chat/test_client.py
+++ b/stream_chat/tests/async_chat/test_client.py
@@ -468,6 +468,9 @@ class TestClient(object):
             "action": "DeleteChannel",
             "owner": False,
             "same_team": True,
+            "condition": {
+                "$subject.magic_custom_field": "magic_custom_value",
+            },
         }
 
         await client.create_permission(custom)

--- a/stream_chat/tests/test_client.py
+++ b/stream_chat/tests/test_client.py
@@ -394,6 +394,9 @@ class TestClient(object):
             "action": "DeleteChannel",
             "owner": False,
             "same_team": True,
+            "condition": {
+                "$subject.magic_custom_field": "magic_custom_value",
+            },
         }
 
         client.create_permission(custom)


### PR DESCRIPTION
Condition is now required attribute of custom permissions. The API change is not live yet