### PR TITLE
Fix KeyError on test_export_channel. Fix typo umute to unmute

### DIFF
--- a/stream_chat/tests/async_chat/test_channel.py
+++ b/stream_chat/tests/async_chat/test_channel.py
@@ -280,7 +280,7 @@ class TestChannel(object):
         assert response[1]["user"]["id"] == "john2"
 
     @pytest.mark.asyncio
-    async def test_mute_umute(self, event_loop, client, channel, random_users):
+    async def test_mute_unmute(self, event_loop, client, channel, random_users):
         user_id = random_users[0]["id"]
         response = await channel.mute(user_id, expiration=30000)
         assert "channel_mute" in response
@@ -324,6 +324,5 @@ class TestChannel(object):
             if resp["status"] == "completed":
                 assert len(resp["result"]) != 0
                 assert resp["result"]["url"] != ""
-                assert len(resp["error"]) != 0
                 break
             time.sleep(0.5)

--- a/stream_chat/tests/test_channel.py
+++ b/stream_chat/tests/test_channel.py
@@ -295,6 +295,5 @@ class TestChannel(object):
             if resp["status"] == "completed":
                 assert len(resp["result"]) != 0
                 assert resp["result"]["url"] != ""
-                assert len(resp["error"]) != 0
                 break
             time.sleep(0.5)


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

So I tried to run `make test` and `test_export_channel` failed because the `error` field does not exist on the response.