### PR TITLE
Use resp.json() on async parse response.

### DIFF
--- a/stream_chat/async_chat/client.py
+++ b/stream_chat/async_chat/client.py
@@ -37,8 +37,8 @@ class StreamChatAsync(StreamChatInterface):
     async def _parse_response(self, response):
         text = await response.text()
         try:
-            parsed_result = json.loads(text) if text else {}
-        except ValueError:
+            parsed_result = await response.json() if text else {}
+        except aiohttp.ClientResponseError:
             raise StreamAPIException(text, response.status)
         if response.status >= 399:
             raise StreamAPIException(text, response.status)
@@ -242,7 +242,7 @@ class StreamChatAsync(StreamChatInterface):
         return Channel(self, channel_type, channel_id, data)
 
     async def delete_channels(self, cids, **options):
-        return await self.post(f"channels/delete", data=dict(options, cids=cids))
+        return await self.post("channels/delete", data=dict(options, cids=cids))
 
     async def list_commands(self):
         return await self.get("commands")

--- a/stream_chat/client.py
+++ b/stream_chat/client.py
@@ -238,7 +238,7 @@ class StreamChat(StreamChatInterface):
         return Channel(self, channel_type, channel_id, data)
 
     def delete_channels(self, cids, **options):
-        return self.post(f"channels/delete", data=dict(options, cids=cids))
+        return self.post("channels/delete", data=dict(options, cids=cids))
 
     def list_commands(self):
         return self.get("commands")


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
This PR is for issue #46. I use `response.json(content_type=None)` specifically to get the same behavior with `json.loads()`. For example, if we simply use `response.json()`, we get error on `test_auth_exception` with message ` 'Attempt to decode JSON with unexpected mimetype: text/plain', url=URL('https://chat.stream-io-api.com/channeltypes/team?api_key=bad'`.
