### PR TITLE
ci: remove event_loop param from tests

### DIFF
--- a/stream_chat/tests/async_chat/conftest.py
+++ b/stream_chat/tests/async_chat/conftest.py
@@ -26,8 +26,7 @@ def pytest_configure(config):
 
 
 @pytest.fixture(scope="module")
-def event_loop(request):
-    """Create an instance of the default event loop for each test case."""
+def event_loop():
     loop = asyncio.get_event_loop_policy().new_event_loop()
     yield loop
     loop.close()

--- a/stream_chat/tests/async_chat/test_channel.py
+++ b/stream_chat/tests/async_chat/test_channel.py
@@ -8,7 +8,7 @@ from stream_chat.base.exceptions import StreamAPIException
 @pytest.mark.incremental
 class TestChannel(object):
     @pytest.mark.asyncio
-    async def test_ban_user(self, event_loop, channel, random_user, server_user):
+    async def test_ban_user(self, channel, random_user, server_user):
         await channel.ban_user(random_user["id"], user_id=server_user["id"])
         await channel.ban_user(
             random_user["id"],
@@ -19,7 +19,7 @@ class TestChannel(object):
         await channel.unban_user(random_user["id"])
 
     @pytest.mark.asyncio
-    async def test_create_without_id(self, event_loop, client, random_users):
+    async def test_create_without_id(self, client, random_users):
         channel = client.channel(
             "messaging", data={"members": [u["id"] for u in random_users]}
         )
@@ -29,7 +29,7 @@ class TestChannel(object):
         assert channel.id is not None
 
     @pytest.mark.asyncio
-    async def test_send_message_with_options(self, event_loop, channel, random_user):
+    async def test_send_message_with_options(self, channel, random_user):
         response = await channel.send_message(
             {"text": "hi"}, random_user["id"], skip_push=True
         )
@@ -37,13 +37,13 @@ class TestChannel(object):
         assert response["message"]["text"] == "hi"
 
     @pytest.mark.asyncio
-    async def test_send_event(self, event_loop, channel, random_user):
+    async def test_send_event(self, channel, random_user):
         response = await channel.send_event({"type": "typing.start"}, random_user["id"])
         assert "event" in response
         assert response["event"]["type"] == "typing.start"
 
     @pytest.mark.asyncio
-    async def test_send_reaction(self, event_loop, channel, random_user):
+    async def test_send_reaction(self, channel, random_user):
         msg = await channel.send_message({"text": "hi"}, random_user["id"])
         response = await channel.send_reaction(
             msg["message"]["id"], {"type": "love"}, random_user["id"]
@@ -53,7 +53,7 @@ class TestChannel(object):
         assert response["message"]["latest_reactions"][0]["type"] == "love"
 
     @pytest.mark.asyncio
-    async def test_delete_reaction(self, event_loop, channel, random_user):
+    async def test_delete_reaction(self, channel, random_user):
         msg = await channel.send_message({"text": "hi"}, random_user["id"])
         await channel.send_reaction(
             msg["message"]["id"], {"type": "love"}, random_user["id"]
@@ -65,13 +65,13 @@ class TestChannel(object):
         assert len(response["message"]["latest_reactions"]) == 0
 
     @pytest.mark.asyncio
-    async def test_update(self, event_loop, channel):
+    async def test_update(self, channel):
         response = await channel.update({"motd": "one apple a day..."})
         assert "channel" in response
         assert response["channel"]["motd"] == "one apple a day..."
 
     @pytest.mark.asyncio
-    async def test_update_partial(self, event_loop, channel):
+    async def test_update_partial(self, channel):
         response = await channel.update({"color": "blue", "age": 30})
         assert "channel" in response
         assert response["channel"]["color"] == "blue"
@@ -85,18 +85,18 @@ class TestChannel(object):
         assert "age" not in response["channel"]
 
     @pytest.mark.asyncio
-    async def test_delete(self, event_loop, channel):
+    async def test_delete(self, channel):
         response = await channel.delete()
         assert "channel" in response
         assert response["channel"].get("deleted_at") is not None
 
     @pytest.mark.asyncio
-    async def test_truncate(self, event_loop, channel):
+    async def test_truncate(self, channel):
         response = await channel.truncate()
         assert "channel" in response
 
     @pytest.mark.asyncio
-    async def test_truncate_with_options(self, event_loop, channel, random_user):
+    async def test_truncate_with_options(self, channel, random_user):
         response = await channel.truncate(
             skip_push=True,
             message={
@@ -107,7 +107,7 @@ class TestChannel(object):
         assert "channel" in response
 
     @pytest.mark.asyncio
-    async def test_add_members(self, event_loop, channel, random_user):
+    async def test_add_members(self, channel, random_user):
         response = await channel.remove_members([random_user["id"]])
         assert len(response["members"]) == 0
 
@@ -116,7 +116,7 @@ class TestChannel(object):
         assert not response["members"][0].get("is_moderator", False)
 
     @pytest.mark.asyncio
-    async def test_invite_members(self, event_loop, channel, random_user):
+    async def test_invite_members(self, channel, random_user):
         response = await channel.remove_members([random_user["id"]])
         assert len(response["members"]) == 0
 
@@ -125,7 +125,7 @@ class TestChannel(object):
         assert response["members"][0].get("invited", True)
 
     @pytest.mark.asyncio
-    async def test_add_moderators(self, event_loop, channel, random_user):
+    async def test_add_moderators(self, channel, random_user):
         response = await channel.add_moderators([random_user["id"]])
         assert response["members"][0]["is_moderator"]
 
@@ -133,7 +133,7 @@ class TestChannel(object):
         assert not response["members"][0].get("is_moderator", False)
 
     @pytest.mark.asyncio
-    async def test_assign_roles_moderators(self, event_loop, channel, random_user):
+    async def test_assign_roles_moderators(self, channel, random_user):
         member = {"user_id": random_user["id"], "channel_role": "channel_moderator"}
         response = await channel.add_members([member])
         assert len(response["members"]) == 1
@@ -145,13 +145,13 @@ class TestChannel(object):
         assert response["members"][0]["channel_role"] == "channel_member"
 
     @pytest.mark.asyncio
-    async def test_mark_read(self, event_loop, channel, random_user):
+    async def test_mark_read(self, channel, random_user):
         response = await channel.mark_read(random_user["id"])
         assert "event" in response
         assert response["event"]["type"] == "message.read"
 
     @pytest.mark.asyncio
-    async def test_get_replies(self, event_loop, channel, random_user):
+    async def test_get_replies(self, channel, random_user):
         msg = await channel.send_message({"text": "hi"}, random_user["id"])
         response = await channel.get_replies(msg["message"]["id"])
         assert "messages" in response
@@ -173,7 +173,7 @@ class TestChannel(object):
         assert response["messages"][0]["index"] == 7
 
     @pytest.mark.asyncio
-    async def test_get_reactions(self, event_loop, channel, random_user):
+    async def test_get_reactions(self, channel, random_user):
         msg = await channel.send_message({"text": "hi"}, random_user["id"])
         response = await channel.get_reactions(msg["message"]["id"])
 
@@ -197,14 +197,14 @@ class TestChannel(object):
         assert response["reactions"][0]["count"] == 42
 
     @pytest.mark.asyncio
-    async def test_send_and_delete_file(self, event_loop, channel, random_user):
+    async def test_send_and_delete_file(self, channel, random_user):
         url = "helloworld.jpg"
         resp = await channel.send_file(url, "helloworld.jpg", random_user)
         assert "helloworld.jpg" in resp["file"]
         await channel.delete_file(resp["file"])
 
     @pytest.mark.asyncio
-    async def test_send_and_delete_image(self, event_loop, channel, random_user):
+    async def test_send_and_delete_image(self, channel, random_user):
         url = "helloworld.jpg"
         resp = await channel.send_image(
             url, "helloworld.jpg", random_user, content_type="image/jpeg"
@@ -213,7 +213,7 @@ class TestChannel(object):
         await channel.delete_image(resp["file"])
 
     @pytest.mark.asyncio
-    async def test_channel_hide_show(self, event_loop, client, channel, random_users):
+    async def test_channel_hide_show(self, client, channel, random_users):
         # setup
         await channel.add_members([u["id"] for u in random_users])
         # verify
@@ -255,7 +255,7 @@ class TestChannel(object):
         assert len(response["channels"]) == 1
 
     @pytest.mark.asyncio
-    async def test_invites(self, event_loop, client, channel):
+    async def test_invites(self, client, channel):
         members = ["john", "paul", "george", "pete", "ringo", "eric"]
         await client.update_users([{"id": m} for m in members])
         channel = client.channel(
@@ -285,7 +285,7 @@ class TestChannel(object):
         await channel.reject_invite("eric")
 
     @pytest.mark.asyncio
-    async def test_query_members(self, event_loop, client, channel):
+    async def test_query_members(self, client, channel):
         members = ["paul", "george", "john", "jessica", "john2"]
         await client.update_users([{"id": m, "name": m} for m in members])
         for member in members:
@@ -303,7 +303,7 @@ class TestChannel(object):
         assert response[1]["user"]["id"] == "john2"
 
     @pytest.mark.asyncio
-    async def test_mute_unmute(self, event_loop, client, channel, random_users):
+    async def test_mute_unmute(self, client, channel, random_users):
         user_id = random_users[0]["id"]
         response = await channel.mute(user_id, expiration=30000)
         assert "channel_mute" in response

--- a/stream_chat/tests/async_chat/test_client.py
+++ b/stream_chat/tests/async_chat/test_client.py
@@ -33,7 +33,7 @@ class TestClient(object):
             assert sorted(actual, key=itemgetter("field")) == expected
 
     @pytest.mark.asyncio
-    async def test_mute_user(self, event_loop, client, random_users):
+    async def test_mute_user(self, client, random_users):
         response = await client.mute_user(random_users[0]["id"], random_users[1]["id"])
         assert "mute" in response
         assert "expires" not in response["mute"]
@@ -42,7 +42,7 @@ class TestClient(object):
         await client.unmute_user(random_users[0]["id"], random_users[1]["id"])
 
     @pytest.mark.asyncio
-    async def test_mute_user_with_timeout(self, event_loop, client, random_users):
+    async def test_mute_user_with_timeout(self, client, random_users):
         response = await client.mute_user(
             random_users[0]["id"], random_users[1]["id"], timeout=10
         )
@@ -53,7 +53,7 @@ class TestClient(object):
         await client.unmute_user(random_users[0]["id"], random_users[1]["id"])
 
     @pytest.mark.asyncio
-    async def test_get_message(self, event_loop, client, channel, random_user):
+    async def test_get_message(self, client, channel, random_user):
         msg_id = str(uuid.uuid4())
         await channel.send_message(
             {"id": msg_id, "text": "helloworld"}, random_user["id"]
@@ -73,28 +73,28 @@ class TestClient(object):
                 await client.get_channel_type("team")
 
     @pytest.mark.asyncio
-    async def test_get_channel_types(self, event_loop, client):
+    async def test_get_channel_types(self, client):
         response = await client.get_channel_type("team")
         assert "permissions" in response
 
     @pytest.mark.asyncio
-    async def test_list_channel_types(self, event_loop, client):
+    async def test_list_channel_types(self, client):
         response = await client.list_channel_types()
         assert "channel_types" in response
 
     @pytest.mark.asyncio
-    async def test_update_channel_type(self, event_loop, client):
+    async def test_update_channel_type(self, client):
         response = await client.update_channel_type("team", commands=["ban", "unban"])
         assert "commands" in response
         assert response["commands"] == ["ban", "unban"]
 
     @pytest.mark.asyncio
-    async def test_get_command(self, client, event_loop, command):
+    async def test_get_command(self, client, command):
         response = await client.get_command(command["name"])
         assert command["name"] == response["name"]
 
     @pytest.mark.asyncio
-    async def test_update_command(self, client, event_loop, command):
+    async def test_update_command(self, client, command):
         response = await client.update_command(
             command["name"], description="My new command"
         )
@@ -102,37 +102,37 @@ class TestClient(object):
         assert "My new command" == response["command"]["description"]
 
     @pytest.mark.asyncio
-    async def test_list_commands(self, event_loop, client):
+    async def test_list_commands(self, client):
         response = await client.list_commands()
         assert "commands" in response
 
-    def test_create_token(self, event_loop, client):
+    def test_create_token(self, client):
         token = client.create_token("tommaso")
         assert type(token) is str
         payload = jwt.decode(token, client.api_secret, algorithms=["HS256"])
         assert payload.get("user_id") == "tommaso"
 
     @pytest.mark.asyncio
-    async def test_get_app_settings(self, event_loop, client):
+    async def test_get_app_settings(self, client):
         configs = await client.get_app_settings()
         assert "app" in configs
 
     @pytest.mark.asyncio
-    async def test_update_user(self, event_loop, client):
+    async def test_update_user(self, client):
         user = {"id": str(uuid.uuid4())}
         response = await client.update_user(user)
         assert "users" in response
         assert user["id"] in response["users"]
 
     @pytest.mark.asyncio
-    async def test_update_users(self, event_loop, client):
+    async def test_update_users(self, client):
         user = {"id": str(uuid.uuid4())}
         response = await client.update_users([user])
         assert "users" in response
         assert user["id"] in response["users"]
 
     @pytest.mark.asyncio
-    async def test_update_user_partial(self, event_loop, client):
+    async def test_update_user_partial(self, client):
         user_id = str(uuid.uuid4())
         await client.update_user({"id": user_id, "field": "value"})
 
@@ -145,13 +145,13 @@ class TestClient(object):
         assert response["users"][user_id]["field"] == "updated"
 
     @pytest.mark.asyncio
-    async def test_delete_user(self, event_loop, client, random_user):
+    async def test_delete_user(self, client, random_user):
         response = await client.delete_user(random_user["id"])
         assert "user" in response
         assert random_user["id"] == response["user"]["id"]
 
     @pytest.mark.asyncio
-    async def test_delete_users(self, event_loop, client, random_user):
+    async def test_delete_users(self, client, random_user):
         response = await client.delete_users(
             [random_user["id"]], "hard", conversations="hard", messages="hard"
         )
@@ -169,13 +169,13 @@ class TestClient(object):
         assert False, "task did not succeed"
 
     @pytest.mark.asyncio
-    async def test_deactivate_user(self, event_loop, client, random_user):
+    async def test_deactivate_user(self, client, random_user):
         response = await client.deactivate_user(random_user["id"])
         assert "user" in response
         assert random_user["id"] == response["user"]["id"]
 
     @pytest.mark.asyncio
-    async def test_reactivate_user(self, event_loop, client, random_user):
+    async def test_reactivate_user(self, client, random_user):
         response = await client.deactivate_user(random_user["id"])
         assert "user" in response
         assert random_user["id"] == response["user"]["id"]
@@ -184,19 +184,17 @@ class TestClient(object):
         assert random_user["id"] == response["user"]["id"]
 
     @pytest.mark.asyncio
-    async def test_export_user(self, event_loop, client, fellowship_of_the_ring):
+    async def test_export_user(self, client, fellowship_of_the_ring):
         response = await client.export_user("gandalf")
         assert "user" in response
         assert response["user"]["name"] == "Gandalf the Grey"
 
     @pytest.mark.asyncio
-    async def test_ban_user(self, event_loop, client, random_user, server_user):
+    async def test_ban_user(self, client, random_user, server_user):
         await client.ban_user(random_user["id"], user_id=server_user["id"])
 
     @pytest.mark.asyncio
-    async def test_shadow_ban(
-        self, event_loop, client, random_user, server_user, channel
-    ):
+    async def test_shadow_ban(self, client, random_user, server_user, channel):
         msg_id = str(uuid.uuid4())
         response = await channel.send_message(
             {"id": msg_id, "text": "hello world"}, random_user["id"]
@@ -228,25 +226,25 @@ class TestClient(object):
         assert not response["message"]["shadowed"]
 
     @pytest.mark.asyncio
-    async def test_unban_user(self, event_loop, client, random_user, server_user):
+    async def test_unban_user(self, client, random_user, server_user):
         await client.ban_user(random_user["id"], user_id=server_user["id"])
         await client.unban_user(random_user["id"], user_id=server_user["id"])
 
     @pytest.mark.asyncio
-    async def test_flag_user(self, event_loop, client, random_user, server_user):
+    async def test_flag_user(self, client, random_user, server_user):
         await client.flag_user(random_user["id"], user_id=server_user["id"])
 
     @pytest.mark.asyncio
-    async def test_unflag_user(self, event_loop, client, random_user, server_user):
+    async def test_unflag_user(self, client, random_user, server_user):
         await client.flag_user(random_user["id"], user_id=server_user["id"])
         await client.unflag_user(random_user["id"], user_id=server_user["id"])
 
     @pytest.mark.asyncio
-    async def test_mark_all_read(self, event_loop, client, random_user):
+    async def test_mark_all_read(self, client, random_user):
         await client.mark_all_read(random_user["id"])
 
     @pytest.mark.asyncio
-    async def test_pin_unpin_message(self, event_loop, client, channel, random_user):
+    async def test_pin_unpin_message(self, client, channel, random_user):
         msg_id = str(uuid.uuid4())
         response = await channel.send_message(
             {"id": msg_id, "text": "hello world"}, random_user["id"]
@@ -261,7 +259,7 @@ class TestClient(object):
         assert response["message"]["pinned_by"] is None
 
     @pytest.mark.asyncio
-    async def test_update_message(self, event_loop, client, channel, random_user):
+    async def test_update_message(self, client, channel, random_user):
         msg_id = str(uuid.uuid4())
         response = await channel.send_message(
             {"id": msg_id, "text": "hello world"}, random_user["id"]
@@ -277,9 +275,7 @@ class TestClient(object):
         )
 
     @pytest.mark.asyncio
-    async def test_update_message_partial(
-        self, event_loop, client, channel, random_user
-    ):
+    async def test_update_message_partial(self, client, channel, random_user):
         msg_id = str(uuid.uuid4())
         response = await channel.send_message(
             {"id": msg_id, "text": "hello world"}, random_user["id"]
@@ -294,7 +290,7 @@ class TestClient(object):
         assert response["message"]["awesome"] is True
 
     @pytest.mark.asyncio
-    async def test_delete_message(self, event_loop, client, channel, random_user):
+    async def test_delete_message(self, client, channel, random_user):
         msg_id = str(uuid.uuid4())
         await channel.send_message(
             {"id": msg_id, "text": "helloworld"}, random_user["id"]
@@ -307,9 +303,7 @@ class TestClient(object):
         await client.delete_message(msg_id, hard=True)
 
     @pytest.mark.asyncio
-    async def test_flag_message(
-        self, event_loop, client, channel, random_user, server_user
-    ):
+    async def test_flag_message(self, client, channel, random_user, server_user):
         msg_id = str(uuid.uuid4())
         await channel.send_message(
             {"id": msg_id, "text": "helloworld"}, random_user["id"]
@@ -317,9 +311,7 @@ class TestClient(object):
         await client.flag_message(msg_id, user_id=server_user["id"])
 
     @pytest.mark.asyncio
-    async def test_query_message_flags(
-        self, event_loop, client, channel, random_user, server_user
-    ):
+    async def test_query_message_flags(self, client, channel, random_user, server_user):
         msg_id = str(uuid.uuid4())
         await channel.send_message(
             {"id": msg_id, "text": "helloworld"}, random_user["id"]
@@ -333,9 +325,7 @@ class TestClient(object):
         assert len(response["flags"]) == 1
 
     @pytest.mark.asyncio
-    async def test_unflag_message(
-        self, event_loop, client, channel, random_user, server_user
-    ):
+    async def test_unflag_message(self, client, channel, random_user, server_user):
         msg_id = str(uuid.uuid4())
         await channel.send_message(
             {"id": msg_id, "text": "helloworld"}, random_user["id"]
@@ -344,15 +334,13 @@ class TestClient(object):
         await client.unflag_message(msg_id, user_id=server_user["id"])
 
     @pytest.mark.asyncio
-    async def test_query_users_young_hobbits(
-        self, event_loop, client, fellowship_of_the_ring
-    ):
+    async def test_query_users_young_hobbits(self, client, fellowship_of_the_ring):
         response = await client.query_users({"race": {"$eq": "Hobbit"}}, {"age": -1})
         assert len(response["users"]) == 4
         assert [50, 38, 36, 28] == [u["age"] for u in response["users"]]
 
     @pytest.mark.asyncio
-    async def test_devices(self, event_loop, client, random_user):
+    async def test_devices(self, client, random_user):
         response = await client.get_devices(random_user["id"])
         assert "devices" in response
         assert len(response["devices"]) == 0
@@ -367,7 +355,7 @@ class TestClient(object):
         assert len(response["devices"]) == 1
 
     @pytest.mark.asyncio
-    async def test_get_rate_limits(self, event_loop, client):
+    async def test_get_rate_limits(self, client):
         response = await client.get_rate_limits()
         assert "server_side" in response
         assert "android" in response
@@ -488,9 +476,7 @@ class TestClient(object):
             )
 
     @pytest.mark.asyncio
-    async def test_query_channels_members_in(
-        self, event_loop, client, fellowship_of_the_ring
-    ):
+    async def test_query_channels_members_in(self, client, fellowship_of_the_ring):
         response = await client.query_channels(
             {"members": {"$in": ["gimli"]}}, {"id": 1}
         )
@@ -499,30 +485,30 @@ class TestClient(object):
         assert len(response["channels"][0]["members"]) == 9
 
     @pytest.mark.asyncio
-    async def test_create_blocklist(self, event_loop, client):
+    async def test_create_blocklist(self, client):
         await client.create_blocklist(name="Foo", words=["fudge", "heck"])
 
     @pytest.mark.asyncio
-    async def test_list_blocklists(self, event_loop, client):
+    async def test_list_blocklists(self, client):
         response = await client.list_blocklists()
         assert len(response["blocklists"]) == 2
         blocklist_names = {blocklist["name"] for blocklist in response["blocklists"]}
         assert "Foo" in blocklist_names
 
     @pytest.mark.asyncio
-    async def test_get_blocklist(self, event_loop, client):
+    async def test_get_blocklist(self, client):
         response = await client.get_blocklist("Foo")
         assert response["blocklist"]["name"] == "Foo"
         assert response["blocklist"]["words"] == ["fudge", "heck"]
 
     @pytest.mark.asyncio
-    async def test_update_blocklist(self, event_loop, client):
+    async def test_update_blocklist(self, client):
         await client.update_blocklist("Foo", words=["dang"])
         response = await client.get_blocklist("Foo")
         assert response["blocklist"]["words"] == ["dang"]
 
     @pytest.mark.asyncio
-    async def test_delete_blocklist(self, event_loop, client):
+    async def test_delete_blocklist(self, client):
         await client.delete_blocklist("Foo")
 
     @pytest.mark.asyncio
@@ -593,7 +579,7 @@ class TestClient(object):
         assert role not in response["roles"]
 
     @pytest.mark.asyncio
-    async def test_delete_channels(self, event_loop, client, channel):
+    async def test_delete_channels(self, client, channel):
         response = await client.delete_channels([channel.cid])
         assert "task_id" in response
 


### PR DESCRIPTION
Removing event_loop parameter as it seems unneccesary.

This came from a discussion here: https://github.com/GetStream/stream-chat-python/pull/86