### PR TITLE
feat: add options to add members api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ secrets.*sh
 .idea
 
 .venv
+.python-version
 pip-selfcheck.json
 .idea
 .vscode

--- a/stream_chat/async_chat/channel.py
+++ b/stream_chat/async_chat/channel.py
@@ -148,17 +148,17 @@ class Channel(ChannelInterface):
         """
         return await self.client.post(f"{self.url}/truncate", data=options)
 
-    async def add_members(self, members, message=None):
+    async def add_members(self, members, message=None, **options):
         """
         Adds members to the channel
 
         :param members: member objects to add
         :param message: An optional to show
+        :param options: additional options such as hide_history
         :return:
         """
-        return await self.client.post(
-            self.url, data={"add_members": members, "message": message}
-        )
+        payload = {"add_members": members, "message": message, **options}
+        return await self.client.post(self.url, data=payload)
 
     async def assign_roles(self, members, message=None):
         """

--- a/stream_chat/base/channel.py
+++ b/stream_chat/base/channel.py
@@ -149,12 +149,13 @@ class ChannelInterface(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def add_members(self, members, message=None):
+    def add_members(self, members, message=None, **options):
         """
         Adds members to the channel
 
         :param members: member objects to add
         :param message: An optional to show
+        :param options: additional options such as hide_history
         :return:
         """
         pass

--- a/stream_chat/channel.py
+++ b/stream_chat/channel.py
@@ -146,17 +146,17 @@ class Channel(ChannelInterface):
         """
         return self.client.post(f"{self.url}/truncate", data=options)
 
-    def add_members(self, members, message=None):
+    def add_members(self, members, message=None, **options):
         """
         Adds members to the channel
 
         :param members: member objects to add
         :param message: An optional to show
+        :param options: additional options such as hide_history
         :return:
         """
-        return self.client.post(
-            self.url, data={"add_members": members, "message": message}
-        )
+        payload = {"add_members": members, "message": message, **options}
+        return self.client.post(self.url, data=payload)
 
     def assign_roles(self, members, message=None):
         """

--- a/stream_chat/tests/async_chat/test_channel.py
+++ b/stream_chat/tests/async_chat/test_channel.py
@@ -116,6 +116,14 @@ class TestChannel(object):
         assert not response["members"][0].get("is_moderator", False)
 
     @pytest.mark.asyncio
+    async def test_add_members_with_options(self, channel, random_user):
+        response = await channel.remove_members([random_user["id"]])
+        assert len(response["members"]) == 0
+
+        response = await channel.add_members([random_user["id"]], hide_history=True)
+        assert len(response["members"]) == 1
+
+    @pytest.mark.asyncio
     async def test_invite_members(self, channel, random_user):
         response = await channel.remove_members([random_user["id"]])
         assert len(response["members"]) == 0

--- a/stream_chat/tests/test_channel.py
+++ b/stream_chat/tests/test_channel.py
@@ -100,6 +100,13 @@ class TestChannel(object):
         assert len(response["members"]) == 1
         assert not response["members"][0].get("is_moderator", False)
 
+    def test_add_members_with_additional_options(self, channel, random_user):
+        response = channel.remove_members([random_user["id"]])
+        assert len(response["members"]) == 0
+
+        response = channel.add_members([random_user["id"]], hide_history=True)
+        assert len(response["members"]) == 1
+
     def test_invite_members(self, channel, random_user):
         response = channel.remove_members([random_user["id"]])
         assert len(response["members"]) == 0


### PR DESCRIPTION
As part of CHAT-2700, add hide history support for add members API.