### PR TITLE
feat: add type hints and mypy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,10 @@ name: build
 on:
   push:
     branches:
-      - 'master'
+      - "master"
   pull_request:
 
-concurrency: 
+concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
   cancel-in-progress: true
 
@@ -15,16 +15,12 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        python: [3.6, 3.7, 3.8, 3.9, '3.10']
+        python: [3.6, 3.7, 3.8, 3.9, "3.10"]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
-
-      - name: Add pip bin to PATH
-        run: |
-          echo "/home/runner/.local/bin" >> $GITHUB_PATH
 
       - name: Install deps with ${{ matrix.python }}
         run: pip install ".[test, ci]"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
       - 'master'
   pull_request:
 
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -33,6 +37,5 @@ jobs:
         env:
           STREAM_KEY: ${{ secrets.STREAM_KEY }}
           STREAM_SECRET: ${{ secrets.STREAM_SECRET }}
-        run: |
-          python setup.py install
-          make test
+          PYTHONPATH: ${{ github.workspace }}
+        run: make test

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,0 +1,29 @@
+name: reviewdog
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  reviewdog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: reviewdog/action-setup@v1
+        with:
+          reviewdog_version: latest
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.10"
+
+      - name: Install deps
+        run: pip install ".[ci]"
+
+      - name: Reviewdog
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: make reviewdog

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ var/
 .installed.cfg
 *.egg
 include/
+.DS_Store
 
 # Installer logs
 pip-log.txt
@@ -42,6 +43,7 @@ coverage.xml
 .mr.developer.cfg
 .project
 .pydevproject
+.coverage*
 
 # Rope
 .ropeproject
@@ -62,6 +64,7 @@ pip-selfcheck.json
 .idea
 .vscode
 *,cover
+.mypy_cache
 .eggs
 .env
 .envrc

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include README.md
+include stream_chat/py.typed

--- a/Makefile
+++ b/Makefile
@@ -11,12 +11,13 @@ help: ## Display this help message
 
 lint:  ## Run linters
 	black --check stream_chat
-	flake8 --ignore=E501,E225,W293,W503,F401 stream_chat
+	flake8 --ignore=E501,W503 stream_chat
+	mypy stream_chat
 
 lint-fix:
 	black stream_chat
 
 test:  ## Run tests
-	STREAM_KEY=$(STREAM_KEY) STREAM_SECRET=$(STREAM_SECRET) python setup.py test
+	STREAM_KEY=$(STREAM_KEY) STREAM_SECRET=$(STREAM_SECRET) pytest --cov=stream_chat --cov-report=xml stream_chat/tests
 
 check: lint test  ## Run linters + tests

--- a/Makefile
+++ b/Makefile
@@ -21,3 +21,8 @@ test:  ## Run tests
 	STREAM_KEY=$(STREAM_KEY) STREAM_SECRET=$(STREAM_SECRET) pytest --cov=stream_chat --cov-report=xml stream_chat/tests
 
 check: lint test  ## Run linters + tests
+
+reviewdog:
+	black --check --diff --quiet stream_chat | reviewdog -f=diff -f.diff.strip=0 -filter-mode="diff_context" -name=black -reporter=github-pr-review
+	flake8 --ignore=E501,W503 stream_chat | reviewdog -f=flake8 -name=flake8 -reporter=github-pr-review
+	mypy --show-column-numbers --show-absolute-path stream_chat | reviewdog -efm="%f:%l:%c: %t%*[^:]: %m" -name=mypy -reporter=github-pr-review

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # stream-chat-python
 
-[![build](https://github.com/GetStream/stream-chat-python/workflows/build/badge.svg)](https://github.com/GetStream/stream-chat-python/actions) [![PyPI version](https://badge.fury.io/py/stream-chat.svg)](http://badge.fury.io/py/stream-chat) ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/stream-chat.svg)
+[![build](https://github.com/GetStream/stream-chat-python/workflows/build/badge.svg)](https://github.com/GetStream/stream-chat-python/actions) [![PyPI version](https://badge.fury.io/py/stream-chat.svg)](http://badge.fury.io/py/stream-chat) ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/stream-chat.svg) [![Checked with mypy](http://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)
 
 the official Python API client for [Stream chat](https://getstream.io/chat/) a service for building chat applications.
 
@@ -36,6 +36,8 @@ pip install stream-chat
 - Campaign API (alpha - susceptible changes and even won't be available in some regions yet)
 
 ### Quickstart
+
+> :bulb: The library is almost 100% typed. Feel free to enable [mypy](https://github.com/python/mypy) for our library. We will introduce more improvements in the future in this area.
 
 #### Sync
 
@@ -125,7 +127,7 @@ In order to release new version you need to be a maintainer on Pypi.
 - Update the version on setup.py
 - Commit and push to Github
 - Create a new tag for the version (eg. `v2.9.0`)
-- Create a new dist with python `python setup.py sdist`
-- Upload the new distributable with twine `twine upload dist/stream-chat-VERSION-NAME.tar.gz`
+- Create a new dist with python `python setup.py sdist bdist_wheel`
+- Upload the new distributable with twine `twine upload dist/*`
 
 If unsure you can also test using the Pypi test servers `twine upload --repository-url https://test.pypi.org/legacy/ dist/stream-chat-VERSION-NAME.tar.gz`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,3 +23,13 @@ exclude = '''
   | dist
 )/
 '''
+
+[tool.mypy]
+disallow_untyped_defs = true
+disallow_untyped_calls = true
+check_untyped_defs = true
+warn_unused_configs = true
+
+[[tool.mypy.overrides]]
+module = "stream_chat.tests.*"
+ignore_errors = true

--- a/setup.py
+++ b/setup.py
@@ -1,65 +1,51 @@
-import sys
-
 from setuptools import find_packages, setup
-from setuptools.command.test import test as TestCommand
 
 install_requires = [
-    "pycryptodomex>=3.8.1,<4",
     "requests>=2.22.0,<3",
-    "chardet>=2.0.0,<4",
     "aiodns>=2.0.0",
     "aiohttp>=3.6.0,<4",
     "aiofile>=3.1,<4",
     "pyjwt>=2.0.0,<3",
+    "typing_extensions; python_version < '3.8'",
 ]
-long_description = open("README.md", "r").read()
 tests_require = ["pytest", "pytest-asyncio"]
-ci_require = ["black", "flake8", "pytest-cov"]
+ci_require = [
+    "black",
+    "flake8",
+    "flake8-bugbear",
+    "pytest-cov",
+    "mypy",
+    "types-requests",
+]
+
+with open("README.md", "r") as f:
+    long_description = f.read()
 
 about = {}
+
 with open("stream_chat/__pkg__.py") as fp:
     exec(fp.read(), about)
 
-
-class PyTest(TestCommand):
-    def finalize_options(self):
-        TestCommand.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self):
-        # import here, cause outside the eggs aren't loaded
-        import pytest
-
-        pytest_cmd = ["stream_chat/", "-v"]
-
-        try:
-            pytest_cmd += [
-                "--cov=stream_chat/",
-                "--cov-report=xml",
-            ]
-        except ImportError:
-            pass
-
-        errno = pytest.main(pytest_cmd)
-        sys.exit(errno)
-
-
 setup(
     name="stream-chat",
-    cmdclass={"test": PyTest},
     version=about["__version__"],
     author=about["__maintainer__"],
     author_email=about["__email__"],
-    url="http://github.com/GetStream/chat-py",
+    url="https://github.com/GetStream/stream-chat-python",
+    project_urls={
+        "Bug Tracker": "https://github.com/GetStream/stream-chat-python/issues",
+        "Documentation": "https://getstream.io/activity-feeds/docs/python/?language=python",
+        "Release Notes": "https://github.com/GetStream/stream-chat-python/releases/tag/v{}".format(
+            about["__version__"]
+        ),
+    },
     description="Client for Stream Chat.",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    packages=find_packages(),
+    packages=find_packages(exclude=["*tests*"]),
     zip_safe=False,
     install_requires=install_requires,
     extras_require={"test": tests_require, "ci": ci_require},
-    tests_require=tests_require,
     include_package_data=True,
     python_requires=">=3.6",
     classifiers=[

--- a/stream_chat/__init__.py
+++ b/stream_chat/__init__.py
@@ -1,2 +1,4 @@
 from .client import StreamChat
 from .async_chat import StreamChatAsync
+
+__all__ = ["StreamChat", "StreamChatAsync"]

--- a/stream_chat/__pkg__.py
+++ b/stream_chat/__pkg__.py
@@ -1,5 +1,5 @@
 __author__ = "Tommaso Barbugli"
-__copyright__ = "Copyright 2019-2021, Stream.io, Inc"
+__copyright__ = "Copyright 2019-2022, Stream.io, Inc"
 __version__ = "3.16.0"
 __maintainer__ = "Tommaso Barbugli"
 __email__ = "support@getstream.io"

--- a/stream_chat/async_chat/__init__.py
+++ b/stream_chat/async_chat/__init__.py
@@ -1,1 +1,3 @@
 from .client import StreamChatAsync
+
+__all__ = ["StreamChatAsync"]

--- a/stream_chat/async_chat/client.py
+++ b/stream_chat/async_chat/client.py
@@ -1,23 +1,35 @@
 import json
 import datetime
 from types import TracebackType
-from typing import Optional, Type
+from typing import (
+    Any,
+    AsyncContextManager,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Type,
+    Union,
+)
 from urllib.parse import urlparse
 
 import aiohttp
 from aiofile import AIOFile
 from aiohttp import FormData
+
 from stream_chat.__pkg__ import __version__
 from stream_chat.async_chat.channel import Channel
 from stream_chat.base.client import StreamChatInterface
 from stream_chat.base.exceptions import StreamAPIException
+from stream_chat.types.stream_response import StreamResponse
 
 
-def get_user_agent():
-    return "stream-python-client-aio-%s" % __version__
+def get_user_agent() -> str:
+    return f"stream-python-client-aio-{__version__}"
 
 
-def get_default_header():
+def get_default_header() -> Dict[str, str]:
     base_headers = {
         "Content-type": "application/json",
         "X-Stream-Client": get_user_agent(),
@@ -25,8 +37,10 @@ def get_default_header():
     return base_headers
 
 
-class StreamChatAsync(StreamChatInterface):
-    def __init__(self, api_key, api_secret, timeout=6.0, **options):
+class StreamChatAsync(StreamChatInterface, AsyncContextManager):
+    def __init__(
+        self, api_key: str, api_secret: str, timeout: float = 6.0, **options: Any
+    ):
         super().__init__(
             api_key=api_key, api_secret=api_secret, timeout=timeout, **options
         )
@@ -34,7 +48,7 @@ class StreamChatAsync(StreamChatInterface):
             connector=aiohttp.TCPConnector(keepalive_timeout=3.9)
         )
 
-    async def _parse_response(self, response):
+    async def _parse_response(self, response: aiohttp.ClientResponse) -> StreamResponse:
         text = await response.text()
         try:
             parsed_result = await response.json() if text else {}
@@ -44,7 +58,13 @@ class StreamChatAsync(StreamChatInterface):
             raise StreamAPIException(text, response.status)
         return parsed_result
 
-    async def _make_request(self, method, relative_url, params=None, data=None):
+    async def _make_request(
+        self,
+        method: Callable,
+        relative_url: str,
+        params: Dict = None,
+        data: Any = None,
+    ) -> StreamResponse:
         params = params or {}
         params = {
             k: str(v).lower() if isinstance(v, bool) else v for k, v in params.items()
@@ -71,79 +91,89 @@ class StreamChatAsync(StreamChatInterface):
         ) as response:
             return await self._parse_response(response)
 
-    async def put(self, relative_url, params=None, data=None):
+    async def put(
+        self, relative_url: str, params: Dict = None, data: Any = None
+    ) -> StreamResponse:
         return await self._make_request(self.session.put, relative_url, params, data)
 
-    async def post(self, relative_url, params=None, data=None):
+    async def post(
+        self, relative_url: str, params: Dict = None, data: Any = None
+    ) -> StreamResponse:
         return await self._make_request(self.session.post, relative_url, params, data)
 
-    async def get(self, relative_url, params=None):
+    async def get(self, relative_url: str, params: Dict = None) -> StreamResponse:
         return await self._make_request(self.session.get, relative_url, params, None)
 
-    async def delete(self, relative_url, params=None):
+    async def delete(self, relative_url: str, params: Dict = None) -> StreamResponse:
         return await self._make_request(self.session.delete, relative_url, params, None)
 
-    async def patch(self, relative_url, params=None, data=None):
+    async def patch(
+        self, relative_url: str, params: Dict = None, data: Any = None
+    ) -> StreamResponse:
         return await self._make_request(self.session.patch, relative_url, params, data)
 
-    async def update_app_settings(self, **settings):
+    async def update_app_settings(self, **settings: Any) -> StreamResponse:
         return await self.patch("app", data=settings)
 
-    async def get_app_settings(self):
+    async def get_app_settings(self) -> StreamResponse:
         return await self.get("app")
 
-    async def update_users(self, users):
+    async def update_users(self, users: List[Dict]) -> StreamResponse:
         return await self.post("users", data={"users": {u["id"]: u for u in users}})
 
-    async def update_user(self, user):
+    async def update_user(self, user: Dict) -> StreamResponse:
         return await self.update_users([user])
 
-    async def update_users_partial(self, updates):
+    async def update_users_partial(self, updates: List[Dict]) -> StreamResponse:
         return await self.patch("users", data={"users": updates})
 
-    async def update_user_partial(self, update):
+    async def update_user_partial(self, update: Dict) -> StreamResponse:
         return await self.update_users_partial([update])
 
-    async def delete_user(self, user_id, **options):
+    async def delete_user(self, user_id: str, **options: Any) -> StreamResponse:
         return await self.delete(f"users/{user_id}", options)
 
-    async def delete_users(self, user_ids, delete_type, **options):
+    async def delete_users(
+        self, user_ids: Iterable[str], delete_type: str, **options: Any
+    ) -> StreamResponse:
         return await self.post(
             "users/delete", data=dict(options, user=delete_type, user_ids=user_ids)
         )
 
-    async def deactivate_user(self, user_id, **options):
+    async def deactivate_user(self, user_id: str, **options: Any) -> StreamResponse:
         return await self.post(f"users/{user_id}/deactivate", data=options)
 
-    async def reactivate_user(self, user_id, **options):
+    async def reactivate_user(self, user_id: str, **options: Any) -> StreamResponse:
         return await self.post(f"users/{user_id}/reactivate", data=options)
 
-    async def export_user(self, user_id, **options):
+    async def export_user(self, user_id: str, **options: Any) -> StreamResponse:
         return await self.get(f"users/{user_id}/export", options)
 
-    async def ban_user(self, target_id, **options):
+    async def ban_user(self, target_id: str, **options: Any) -> StreamResponse:
         data = {"target_user_id": target_id, **options}
         return await self.post("moderation/ban", data=data)
 
-    async def shadow_ban(self, target_id, **options):
+    async def shadow_ban(self, target_id: str, **options: Any) -> StreamResponse:
         return await self.ban_user(target_id, shadow=True, **options)
 
-    async def remove_shadow_ban(self, target_id, **options):
+    async def remove_shadow_ban(self, target_id: str, **options: Any) -> StreamResponse:
         return await self.unban_user(target_id, shadow=True, **options)
 
-    async def unban_user(self, target_id, **options):
+    async def unban_user(self, target_id: str, **options: Any) -> StreamResponse:
         params = {"target_user_id": target_id, **options}
         return await self.delete("moderation/ban", params)
 
-    async def flag_message(self, target_id, **options):
+    async def flag_message(self, target_id: str, **options: Any) -> StreamResponse:
         data = {"target_message_id": target_id, **options}
         return await self.post("moderation/flag", data=data)
 
-    async def unflag_message(self, target_id, **options):
+    async def unflag_message(self, target_id: str, **options: Any) -> StreamResponse:
         data = {"target_message_id": target_id, **options}
         return await self.post("moderation/unflag", data=data)
 
-    async def query_message_flags(self, filter_conditions, **options):
+    async def query_message_flags(
+        self, filter_conditions: Dict, **options: Any
+    ) -> StreamResponse:
         params = {
             **options,
             "filter_conditions": filter_conditions,
@@ -152,42 +182,30 @@ class StreamChatAsync(StreamChatInterface):
             "moderation/flags/message", params={"payload": json.dumps(params)}
         )
 
-    async def flag_user(self, target_id, **options):
+    async def flag_user(self, target_id: str, **options: Any) -> StreamResponse:
         data = {"target_user_id": target_id, **options}
         return await self.post("moderation/flag", data=data)
 
-    async def unflag_user(self, target_id, **options):
+    async def unflag_user(self, target_id: str, **options: Any) -> StreamResponse:
         data = {"target_user_id": target_id, **options}
         return await self.post("moderation/unflag", data=data)
 
-    async def mute_user(self, target_id, user_id, **options):
-        """
-        Create a mute
-
-        :param target_id: the user getting muted
-        :param user_id: the user muting the target
-        :param options: additional mute options
-        :return:
-        """
+    async def mute_user(
+        self, target_id: str, user_id: str, **options: Any
+    ) -> StreamResponse:
         data = {"target_id": target_id, "user_id": user_id, **options}
         return await self.post("moderation/mute", data=data)
 
-    async def unmute_user(self, target_id, user_id):
-        """
-        Removes a mute
-
-        :param target_id: the user getting un-muted
-        :param user_id: the user muting the target
-        :return:
-        """
-
+    async def unmute_user(self, target_id: str, user_id: str) -> StreamResponse:
         data = {"target_id": target_id, "user_id": user_id}
         return await self.post("moderation/unmute", data=data)
 
-    async def mark_all_read(self, user_id):
+    async def mark_all_read(self, user_id: str) -> StreamResponse:
         return await self.post("channels/read", data={"user": {"id": user_id}})
 
-    async def pin_message(self, message_id, user_id, expiration=None):
+    async def pin_message(
+        self, message_id: str, user_id: str, expiration: int = None
+    ) -> StreamResponse:
         updates = {
             "set": {
                 "pinned": True,
@@ -196,7 +214,7 @@ class StreamChatAsync(StreamChatInterface):
         }
         return await self.update_message_partial(message_id, updates, user_id)
 
-    async def unpin_message(self, message_id, user_id):
+    async def unpin_message(self, message_id: str, user_id: str) -> StreamResponse:
         updates = {
             "set": {
                 "pinned": False,
@@ -204,137 +222,111 @@ class StreamChatAsync(StreamChatInterface):
         }
         return await self.update_message_partial(message_id, updates, user_id)
 
-    async def update_message(self, message):
+    async def update_message(self, message: Dict) -> StreamResponse:
         if message.get("id") is None:
             raise ValueError("message must have an id")
         return await self.post(f"messages/{message['id']}", data={"message": message})
 
-    async def update_message_partial(self, message_id, updates, user_id, **options):
+    async def update_message_partial(
+        self, message_id: str, updates: Dict, user_id: str, **options: Any
+    ) -> StreamResponse:
         data = updates.copy()
         if user_id:
             data["user"] = {"id": user_id}
         data.update(options)
         return await self.put(f"messages/{message_id}", data=data)
 
-    async def delete_message(self, message_id, **options):
+    async def delete_message(self, message_id: str, **options: Any) -> StreamResponse:
         return await self.delete(f"messages/{message_id}", options)
 
-    async def get_message(self, message_id):
+    async def get_message(self, message_id: str) -> StreamResponse:
         return await self.get(f"messages/{message_id}")
 
-    async def query_users(self, filter_conditions, sort=None, **options):
+    async def query_users(
+        self, filter_conditions: Dict, sort: List[Dict] = None, **options: Any
+    ) -> StreamResponse:
         params = options.copy()
         params.update(
             {"filter_conditions": filter_conditions, "sort": self.normalize_sort(sort)}
         )
         return await self.get("users", params={"payload": json.dumps(params)})
 
-    async def query_channels(self, filter_conditions, sort=None, **options):
-        params = {"state": True, "watch": False, "presence": False}
+    async def query_channels(
+        self, filter_conditions: Dict, sort: List[Dict] = None, **options: Any
+    ) -> StreamResponse:
+        params: Dict[str, Any] = {"state": True, "watch": False, "presence": False}
         params.update(options)
         params.update(
             {"filter_conditions": filter_conditions, "sort": self.normalize_sort(sort)}
         )
         return await self.post("channels", data=params)
 
-    async def create_channel_type(self, data):
+    async def create_channel_type(self, data: Dict) -> StreamResponse:
         if "commands" not in data or not data["commands"]:
             data["commands"] = ["all"]
         return await self.post("channeltypes", data=data)
 
-    async def get_channel_type(self, channel_type):
+    async def get_channel_type(self, channel_type: str) -> StreamResponse:
         return await self.get(f"channeltypes/{channel_type}")
 
-    async def list_channel_types(self):
+    async def list_channel_types(self) -> StreamResponse:
         return await self.get("channeltypes")
 
-    async def update_channel_type(self, channel_type, **settings):
+    async def update_channel_type(
+        self, channel_type: str, **settings: Any
+    ) -> StreamResponse:
         return await self.put(f"channeltypes/{channel_type}", data=settings)
 
-    async def delete_channel_type(self, channel_type):
-        """
-        Delete a type of channel
-
-        :param channel_type: the channel type
-        :return:
-        """
+    async def delete_channel_type(self, channel_type: str) -> StreamResponse:
         return await self.delete(f"channeltypes/{channel_type}")
 
-    def channel(self, channel_type, channel_id=None, data=None):
-        """
-        Creates a channel object
-
-        :param channel_type: the channel type
-        :param channel_id: the id of the channel
-        :param data: additional data, ie: {"members":[id1, id2, ...]}
-        :return: Channel
-        """
+    def channel(  # type: ignore
+        self, channel_type: str, channel_id: str = None, data: Dict = None
+    ) -> Channel:
         return Channel(self, channel_type, channel_id, data)
 
-    async def delete_channels(self, cids, **options):
+    async def delete_channels(
+        self, cids: Iterable[str], **options: Any
+    ) -> StreamResponse:
         return await self.post("channels/delete", data=dict(options, cids=cids))
 
-    async def list_commands(self):
+    async def list_commands(self) -> StreamResponse:
         return await self.get("commands")
 
-    async def create_command(self, data):
+    async def create_command(self, data: Dict) -> StreamResponse:
         return await self.post("commands", data=data)
 
-    async def delete_command(self, name):
+    async def delete_command(self, name: str) -> StreamResponse:
         return await self.delete(f"commands/{name}")
 
-    async def get_command(self, name):
+    async def get_command(self, name: str) -> StreamResponse:
         return await self.get(f"commands/{name}")
 
-    async def update_command(self, name, **settings):
+    async def update_command(self, name: str, **settings: Any) -> StreamResponse:
         return await self.put(f"commands/{name}", data=settings)
 
-    async def add_device(self, device_id, push_provider, user_id):
-        """
-        Add a device to a user
-
-        :param device_id: the id of the device
-        :param push_provider: the push provider used (apn or firebase)
-        :param user_id: the id of the user
-        :return:
-        """
+    async def add_device(
+        self, device_id: str, push_provider: str, user_id: str
+    ) -> StreamResponse:
         return await self.post(
             "devices",
             data={"id": device_id, "push_provider": push_provider, "user_id": user_id},
         )
 
-    async def delete_device(self, device_id, user_id):
-        """
-        Delete a device for a user
-
-        :param device_id: the id of the device
-        :param user_id: the id of the user
-        :return:
-        """
+    async def delete_device(self, device_id: str, user_id: str) -> StreamResponse:
         return await self.delete("devices", {"id": device_id, "user_id": user_id})
 
-    async def get_devices(self, user_id):
-        """
-        Get the list of devices for a user
-
-        :param user_id: the id of the user
-        :return: list of devices
-        """
+    async def get_devices(self, user_id: str) -> StreamResponse:
         return await self.get("devices", {"user_id": user_id})
 
     async def get_rate_limits(
-        self, server_side=False, android=False, ios=False, web=False, endpoints=None
-    ):
-        """
-        Get rate limit quotas and usage.
-        If no params are toggled, all limits for all endpoints are returned.
-
-        :param server_side: if true, show server_side limits.
-        :param android: if true, show android limits.
-        :param ios: if true, show ios limits.
-        :param web: if true, show web limits.
-        :param endpoints: restrict returned limits to the given list of endpoints.
-        """
+        self,
+        server_side: bool = False,
+        android: bool = False,
+        ios: bool = False,
+        web: bool = False,
+        endpoints: Iterable[str] = None,
+    ) -> StreamResponse:
         params = {}
         if server_side:
             params["server_side"] = "true"
@@ -344,19 +336,27 @@ class StreamChatAsync(StreamChatInterface):
             params["ios"] = "true"
         if web:
             params["web"] = "true"
-        if endpoints is not None and len(endpoints) > 0:
+        if endpoints:
             params["endpoints"] = ",".join(endpoints)
 
         return await self.get("rate_limits", params)
 
-    async def search(self, filter_conditions, query, sort=None, **options):
+    async def search(
+        self,
+        filter_conditions: Dict,
+        query: Union[str, Dict],
+        sort: List[Dict] = None,
+        **options: Any,
+    ) -> StreamResponse:
         if "offset" in options:
             if sort or "next" in options:
                 raise ValueError("cannot use offset with sort or next parameters")
         params = self.create_search_params(filter_conditions, query, sort, **options)
         return await self.get("search", params={"payload": json.dumps(params)})
 
-    async def send_file(self, uri, url, name, user, content_type=None):
+    async def send_file(
+        self, uri: str, url: str, name: str, user: Dict, content_type: str = None
+    ) -> StreamResponse:
         headers = {
             "Authorization": self.auth_token,
             "stream-auth-type": "jwt",
@@ -382,235 +382,116 @@ class StreamChatAsync(StreamChatInterface):
         ) as response:
             return await self._parse_response(response)
 
-    async def create_blocklist(self, name, words):
-        """
-        Create a blocklist
-
-        :param name: the name of the blocklist
-        :param words: list of blocked words
-        :return:
-        """
+    async def create_blocklist(self, name: str, words: Iterable[str]) -> StreamResponse:
         return await self.post("blocklists", data={"name": name, "words": words})
 
-    async def list_blocklists(self):
-        """
-        List blocklists
-
-        :return: list of blocklists
-        """
+    async def list_blocklists(self) -> StreamResponse:
         return await self.get("blocklists")
 
-    async def get_blocklist(self, name):
-        """Get a blocklist by name
-
-        :param name: the name of the blocklist
-        :return: blocklist dict representation
-        """
+    async def get_blocklist(self, name: str) -> StreamResponse:
         return await self.get(f"blocklists/{name}")
 
-    async def update_blocklist(self, name, words):
-        """
-        Update a blocklist
-
-        :param name: the name of the blocklist
-        :param words: the list of blocked words (replaces the current list)
-        :return:
-        """
+    async def update_blocklist(self, name: str, words: Iterable[str]) -> StreamResponse:
         return await self.put(f"blocklists/{name}", data={"words": words})
 
-    async def delete_blocklist(self, name):
-        """Delete a blocklist by name
-
-        :param: the name of the blocklist
-        :return:
-        """
+    async def delete_blocklist(self, name: str) -> StreamResponse:
         return await self.delete(f"blocklists/{name}")
 
-    async def check_sqs(self, sqs_key=None, sqs_secret=None, sqs_url=None):
-        """
-        Check SQS Push settings
-
-        When no parameters are given, the current SQS app settings are used
-
-        :param sqs_key: AWS access key
-        :param sqs_secret: AWS secret key
-        :param sqs_url: URL to SQS queue
-        :return:
-        """
+    async def check_sqs(
+        self, sqs_key: str = None, sqs_secret: str = None, sqs_url: str = None
+    ) -> StreamResponse:
         data = {"sqs_key": sqs_key, "sqs_secret": sqs_secret, "sqs_url": sqs_url}
         return await self.post("check_sqs", data=data)
 
-    async def get_permission(self, id):
-        """
-        Get the definition for a permission
-
-        :param id: ID of the permission
-        """
+    async def get_permission(self, id: str) -> StreamResponse:
         return await self.get(f"permissions/{id}")
 
-    async def create_permission(self, permission):
-        """
-        Create a custom permission
-
-        :param permission: Definition of the permission
-        """
+    async def create_permission(self, permission: Dict) -> StreamResponse:
         return await self.post("permissions", data=permission)
 
-    async def update_permission(self, id, permission):
-        """
-        Update a custom permission
-
-        :param id: ID of the permission
-        :param permission: New definition of the permission
-        """
+    async def update_permission(self, id: str, permission: Dict) -> StreamResponse:
         return await self.put(f"permissions/{id}", data=permission)
 
-    async def delete_permission(self, id):
-        """
-        Delete a custom permission
-
-        :param id: ID of the permission
-        """
+    async def delete_permission(self, id: str) -> StreamResponse:
         return await self.delete(f"permissions/{id}")
 
-    async def list_permissions(self):
-        """
-        List all permissions of the app
-        """
+    async def list_permissions(self) -> StreamResponse:
         return await self.get("permissions")
 
-    async def create_role(self, name):
-        """
-        Create a custom role
-
-        :param name: Name of the role
-        """
+    async def create_role(self, name: str) -> StreamResponse:
         return await self.post("roles", data={"name": name})
 
-    async def delete_role(self, name):
-        """
-        Delete a custom role
-
-        :param name: Name of the role
-        """
+    async def delete_role(self, name: str) -> StreamResponse:
         return await self.delete(f"roles/{name}")
 
-    async def list_roles(self):
-        """
-        List all roles of the app
-        """
+    async def list_roles(self) -> StreamResponse:
         return await self.get("roles")
 
-    async def create_segment(self, segment):
-        """
-        Create a segment
-        """
+    async def create_segment(self, segment: Dict) -> StreamResponse:
         return await self.post("segments", data={"segment": segment})
 
-    async def get_segment(self, segment_id):
-        """
-        Get a segment by id
-        """
+    async def get_segment(self, segment_id: str) -> StreamResponse:
         return await self.get(f"segments/{segment_id}")
 
-    async def list_segments(self, **params):
-        """
-        List segments
-        """
+    async def list_segments(self, **params: Any) -> StreamResponse:
         return await self.get("segments", params)
 
-    async def update_segment(self, segment_id, data):
-        """
-        Update a segment by id
-        """
+    async def update_segment(self, segment_id: str, data: Dict) -> StreamResponse:
         return await self.put(f"segments/{segment_id}", data={"segment": data})
 
-    async def delete_segment(self, segment_id):
-        """
-        Delete a segment by id
-        """
+    async def delete_segment(self, segment_id: str) -> StreamResponse:
         return await self.delete(f"segments/{segment_id}")
 
-    async def create_campaign(self, campaign):
-        """
-        Create a campaign
-        """
+    async def create_campaign(self, campaign: Dict) -> StreamResponse:
         return await self.post("campaigns", data={"campaign": campaign})
 
-    async def get_campaign(self, campaign_id):
-        """
-        Get a campaign by id
-        """
+    async def get_campaign(self, campaign_id: str) -> StreamResponse:
         return await self.get(f"campaigns/{campaign_id}")
 
-    async def list_campaigns(self, **params):
-        """
-        List campaigns
-        """
+    async def list_campaigns(self, **params: Any) -> StreamResponse:
         return await self.get("campaigns", params)
 
-    async def update_campaign(self, campaign_id, data):
-        """
-        Update a campaign
-        """
+    async def update_campaign(self, campaign_id: str, data: Dict) -> StreamResponse:
         return await self.put(f"campaigns/{campaign_id}", data={"campaign": data})
 
-    async def delete_campaign(self, campaign_id):
-        """
-        Delete a campaign by id
-        """
+    async def delete_campaign(self, campaign_id: str) -> StreamResponse:
+
         return await self.delete(f"campaigns/{campaign_id}")
 
-    async def schedule_campaign(self, campaign_id, send_at=None):
-        """
-        Schedule a campaign at given time
-        """
+    async def schedule_campaign(
+        self, campaign_id: str, send_at: int = None
+    ) -> StreamResponse:
         return await self.patch(
             f"campaigns/{campaign_id}/schedule", data={"send_at": send_at}
         )
 
-    async def stop_campaign(self, campaign_id):
-        """
-        Stop a in progress campaign
-        """
+    async def stop_campaign(self, campaign_id: str) -> StreamResponse:
         return await self.patch(f"campaigns/{campaign_id}/stop")
 
-    async def resume_campaign(self, campaign_id):
-        """
-        Resume a stopped campaign
-        """
+    async def resume_campaign(self, campaign_id: str) -> StreamResponse:
         return await self.patch(f"campaigns/{campaign_id}/resume")
 
-    async def test_campaign(self, campaign_id, users):
-        """
-        Trigger a test send of the given campaing to given users
-        """
+    async def test_campaign(
+        self, campaign_id: str, users: Iterable[str]
+    ) -> StreamResponse:
         return await self.post(f"campaigns/{campaign_id}/test", data={"users": users})
 
-    async def revoke_tokens(self, before):
-        """
-        Revokes tokens for an application
-        :param before: date before which the tokens are to be revoked, pass None to reset
-        """
-        if isinstance(before, datetime.datetime):
-            before = before.isoformat()
+    async def revoke_tokens(
+        self, since: Union[str, datetime.datetime]
+    ) -> StreamResponse:
+        if isinstance(since, datetime.datetime):
+            since = since.isoformat()
 
-        await self.update_app_settings({"revoke_tokens_issued_before": before})
+        return await self.update_app_settings(revoke_tokens_issued_before=since)
 
-    async def revoke_user_token(self, user_id, before):
-        """
-        Revokes token for a user
-        :param user_id: user_id of user for which the token needs to be revoked
-        :param before: date before which the tokens are to be revoked, , pass None to reset
-        """
-        await self.revoke_users_token([user_id], before)
+    async def revoke_user_token(
+        self, user_id: str, before: Union[str, datetime.datetime]
+    ) -> StreamResponse:
+        return await self.revoke_users_token([user_id], before)
 
-    async def revoke_users_token(self, user_ids, before):
-        """
-        Revokes tokens for given users
-        :param user_ids: user_ids for user for whom the token needs to be revoked
-        :param before: date before which the tokens are to be revoked, pass None to reset
-        """
+    async def revoke_users_token(
+        self, user_ids: Iterable[str], before: Union[str, datetime.datetime]
+    ) -> StreamResponse:
         if isinstance(before, datetime.datetime):
             before = before.isoformat()
 
@@ -619,26 +500,15 @@ class StreamChatAsync(StreamChatInterface):
             updates.append(
                 {"id": user_id, "set": {"revoke_tokens_issued_before": before}}
             )
-        await self.update_users_partial(updates)
+        return await self.update_users_partial(updates)
 
     async def export_channel(
         self,
-        channel_type,
-        channel_id,
-        messages_since=None,
-        messages_until=None,
-    ):
-        """
-        Requests a channel export
-        :param channel_type: channel_type of channel which needs to be exported
-        :param channel_id: channel_id of channel which needs to be exported
-        :param messages_since: RFC-3339 string or datetime to filter messages since that time, optional
-        :param messages_until: RFC-3339 string or datetime to filter messages until that time, optional
-        :type channel_id: str
-        :type channel_type: str
-        :type messages_since: Union[str, datetime.datetime]
-        :type messages_until: Union[str, datetime.datetime]
-        """
+        channel_type: str,
+        channel_id: str,
+        messages_since: Union[str, datetime.datetime] = None,
+        messages_until: Union[str, datetime.datetime] = None,
+    ) -> StreamResponse:
         if isinstance(messages_since, datetime.datetime):
             messages_since = messages_since.isoformat()
         if isinstance(messages_until, datetime.datetime):
@@ -655,27 +525,16 @@ class StreamChatAsync(StreamChatInterface):
             ]
         )
 
-    async def export_channels(self, channels):
-        """
-        Requests a channels export
-        :param channels_data: list of channel's data which need to be exported with keys:
-        - `channel_type`: str
-        - `channel_id`: str
-        - `messages_since` (optional, nullable): str
-        - `messages_until` (optional, nullable): str
-        :type channels_data: List[Dict[str, str]]
-        """
+    async def export_channels(self, channels: Iterable[Dict]) -> StreamResponse:
         return await self.post("export_channels", data={"channels": channels})
 
-    async def get_export_channel_status(self, task_id: str):
-        """
-        Retrieves status of export
-        :param task_id: task_id of task which status needs to be retrieved
-        :type task_id: str
-        """
+    async def get_export_channel_status(self, task_id: str) -> StreamResponse:
         return await self.get(f"export_channels/{task_id}")
 
-    async def close(self):
+    async def get_task(self, task_id: str) -> StreamResponse:
+        return await self.get(f"tasks/{task_id}")
+
+    async def close(self) -> None:
         await self.session.close()
 
     async def __aenter__(self) -> "StreamChatAsync":
@@ -688,6 +547,3 @@ class StreamChatAsync(StreamChatInterface):
         exc_tb: Optional[TracebackType],
     ) -> None:
         await self.close()
-
-    async def get_task(self, task_id):
-        return await self.get(f"tasks/{task_id}")

--- a/stream_chat/base/channel.py
+++ b/stream_chat/base/channel.py
@@ -1,31 +1,40 @@
 import abc
+from typing import Any, Awaitable, Dict, Iterable, List, Union
 
 from stream_chat.base.exceptions import StreamChannelException
+from stream_chat.types.stream_response import StreamResponse
+from stream_chat.base.client import StreamChatInterface
 
 
 class ChannelInterface(abc.ABC):
-    def __init__(self, client, channel_type, channel_id=None, custom_data=None):
+    def __init__(
+        self,
+        client: StreamChatInterface,
+        channel_type: str,
+        channel_id: str = None,
+        custom_data: Dict = None,
+    ):
         self.channel_type = channel_type
         self.id = channel_id
         self.client = client
-        self.custom_data = custom_data
-        if self.custom_data is None:
-            self.custom_data = {}
+        self.custom_data = custom_data or {}
 
     @property
-    def url(self):
+    def url(self) -> str:
         if self.id is None:
             raise StreamChannelException("channel does not have an id")
         return f"channels/{self.channel_type}/{self.id}"
 
     @property
-    def cid(self):
+    def cid(self) -> str:
         if self.id is None:
             raise StreamChannelException("channel does not have an id")
         return f"{self.channel_type}:{self.id}"
 
     @abc.abstractmethod
-    def send_message(self, message, user_id, **options):
+    def send_message(
+        self, message: Dict, user_id: str, **options: Any
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Send a message to this channel
 
@@ -36,7 +45,9 @@ class ChannelInterface(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def send_event(self, event, user_id):
+    def send_event(
+        self, event: Dict, user_id: str
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Send an event on this channel
 
@@ -47,7 +58,9 @@ class ChannelInterface(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def send_reaction(self, message_id, reaction, user_id):
+    def send_reaction(
+        self, message_id: str, reaction: Dict, user_id: str
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Send a reaction about a message
 
@@ -59,7 +72,9 @@ class ChannelInterface(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def delete_reaction(self, message_id, reaction_type, user_id):
+    def delete_reaction(
+        self, message_id: str, reaction_type: str, user_id: str
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Delete a reaction by user and type
 
@@ -71,7 +86,7 @@ class ChannelInterface(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def create(self, user_id):
+    def create(self, user_id: str) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Create the channel
 
@@ -81,7 +96,7 @@ class ChannelInterface(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def query(self, **options):
+    def query(self, **options: Any) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Query the API for this channel, get messages, members or other channel fields
 
@@ -91,7 +106,9 @@ class ChannelInterface(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def query_members(self, filter_conditions, sort=None, **options):
+    def query_members(
+        self, filter_conditions: Dict, sort: List[Dict] = None, **options: Any
+    ) -> Union[List[Dict], Awaitable[List[Dict]]]:
         """
         Query the API for this channel to filter, sort and paginate its members efficiently.
 
@@ -109,7 +126,9 @@ class ChannelInterface(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def update(self, channel_data, update_message=None):
+    def update(
+        self, channel_data: Dict, update_message: Dict = None
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Edit the channel's custom properties
 
@@ -120,7 +139,9 @@ class ChannelInterface(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def update_partial(self, to_set=None, to_unset=None):
+    def update_partial(
+        self, to_set: Dict = None, to_unset: Iterable[str] = None
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Update channel partially
 
@@ -130,7 +151,7 @@ class ChannelInterface(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def delete(self):
+    def delete(self) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Delete the channel. Messages are permanently removed.
 
@@ -139,7 +160,9 @@ class ChannelInterface(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def truncate(self, **options):
+    def truncate(
+        self, **options: Any
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Removes all messages from the channel
 
@@ -149,7 +172,9 @@ class ChannelInterface(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def add_members(self, members, message=None, **options):
+    def add_members(
+        self, members: Iterable[Dict], message: Dict = None, **options: Any
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Adds members to the channel
 
@@ -161,7 +186,9 @@ class ChannelInterface(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def assign_roles(self, members, message=None):
+    def assign_roles(
+        self, members: Iterable[Dict], message: Dict = None
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Assigns new roles to specified channel members
 
@@ -172,7 +199,9 @@ class ChannelInterface(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def invite_members(self, user_ids, message=None):
+    def invite_members(
+        self, user_ids: Iterable[str], message: Dict = None
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         invite members to the channel
 
@@ -183,7 +212,9 @@ class ChannelInterface(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def add_moderators(self, user_ids, message=None):
+    def add_moderators(
+        self, user_ids: Iterable[str], message: Dict = None
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Adds moderators to the channel
 
@@ -194,7 +225,9 @@ class ChannelInterface(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def remove_members(self, user_ids, message=None):
+    def remove_members(
+        self, user_ids: Iterable[str], message: Dict = None
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Remove members from the channel
 
@@ -205,7 +238,9 @@ class ChannelInterface(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def demote_moderators(self, user_ids, message=None):
+    def demote_moderators(
+        self, user_ids: Iterable[str], message: Dict = None
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Demotes moderators from the channel
 
@@ -216,7 +251,9 @@ class ChannelInterface(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def mark_read(self, user_id, **data):
+    def mark_read(
+        self, user_id: str, **data: Any
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Send the mark read event for this user, only works if the `read_events` setting is enabled
 
@@ -227,7 +264,9 @@ class ChannelInterface(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def get_replies(self, parent_id, **options):
+    def get_replies(
+        self, parent_id: str, **options: Any
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         List the message replies for a parent message
 
@@ -238,7 +277,9 @@ class ChannelInterface(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def get_reactions(self, message_id, **options):
+    def get_reactions(
+        self, message_id: str, **options: Any
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         List the reactions, supports pagination
 
@@ -249,7 +290,9 @@ class ChannelInterface(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def ban_user(self, target_id, **options):
+    def ban_user(
+        self, target_id: str, **options: Any
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Bans a user from this channel
 
@@ -260,7 +303,9 @@ class ChannelInterface(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def unban_user(self, target_id, **options):
+    def unban_user(
+        self, target_id: str, **options: Any
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Removes the ban for a user on this channel
 
@@ -270,45 +315,57 @@ class ChannelInterface(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def accept_invite(self, user_id, **data):
+    def accept_invite(
+        self, user_id: str, **data: Any
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         pass
 
     @abc.abstractmethod
-    def reject_invite(self, user_id, **data):
+    def reject_invite(
+        self, user_id: str, **data: Any
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         pass
 
     @abc.abstractmethod
-    def send_file(self, url, name, user, content_type=None):
+    def send_file(
+        self, url: str, name: str, user: Dict, content_type: str = None
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         pass
 
     @abc.abstractmethod
-    def send_image(self, url, name, user, content_type=None):
+    def send_image(
+        self, url: str, name: str, user: Dict, content_type: str = None
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         pass
 
     @abc.abstractmethod
-    def delete_file(self, url):
+    def delete_file(self, url: str) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         pass
 
     @abc.abstractmethod
-    def delete_image(self, url):
+    def delete_image(
+        self, url: str
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         pass
 
     @abc.abstractmethod
-    def hide(self, user_id):
+    def hide(self, user_id: str) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         pass
 
     @abc.abstractmethod
-    def show(self, user_id):
+    def show(self, user_id: str) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         pass
 
     @abc.abstractmethod
-    def mute(self, user_id, expiration=None):
+    def mute(
+        self, user_id: str, expiration: int = None
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         pass
 
     @abc.abstractmethod
-    def unmute(self, user_id):
+    def unmute(self, user_id: str) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         pass
 
 
-def add_user_id(payload, user_id):
+def add_user_id(payload: Dict, user_id: str) -> Dict:
     return {**payload, "user": {"id": user_id}}

--- a/stream_chat/base/client.py
+++ b/stream_chat/base/client.py
@@ -1,16 +1,22 @@
 import abc
 import collections
+import datetime
 import hashlib
 import hmac
+from typing import Any, Awaitable, Dict, Iterable, List, Union, TypeVar
 
 import jwt
 
+from stream_chat.types.stream_response import StreamResponse
+
+
+TChannel = TypeVar("TChannel")
+
 
 class StreamChatInterface(abc.ABC):
-    session = None
-
-    @abc.abstractmethod
-    def __init__(self, api_key, api_secret, timeout=6.0, **options):
+    def __init__(
+        self, api_key: str, api_secret: str, timeout: float = 6.0, **options: Any
+    ):
         self.api_key = api_key
         self.api_secret = api_secret
         self.timeout = timeout
@@ -20,13 +26,13 @@ class StreamChatInterface(abc.ABC):
             {"server": True}, self.api_secret, algorithm="HS256"
         )
 
-    def get_default_params(self):
+    def get_default_params(self) -> Dict[str, str]:
         return {"api_key": self.api_key}
 
-    def normalize_sort(self, sort=None):
+    def normalize_sort(self, sort: Union[Dict, List[Dict]] = None) -> List[Dict]:
         sort_fields = []
         if isinstance(sort, collections.abc.Mapping):
-            sort = [sort]
+            sort = [sort]  # type: ignore
         if isinstance(sort, list):
             for item in sort:
                 if "field" in item and "direction" in item:
@@ -36,26 +42,36 @@ class StreamChatInterface(abc.ABC):
                         sort_fields.append({"field": k, "direction": v})
         return sort_fields
 
-    def create_token(self, user_id, exp=None, iat=None, **claims):
-        payload = {**claims, "user_id": user_id}
-        if exp is not None:
+    def create_token(
+        self, user_id: str, exp: int = None, iat: int = None, **claims: Any
+    ) -> str:
+        payload: Dict[str, Any] = {**claims, "user_id": user_id}
+        if exp:
             payload["exp"] = exp
-        if iat is not None:
+        if iat:
             payload["iat"] = iat
         return jwt.encode(payload, self.api_secret, algorithm="HS256")
 
-    def create_search_params(self, filter_conditions, query, sort, **options):
+    def create_search_params(
+        self,
+        filter_conditions: Dict,
+        query: Union[str, Dict],
+        sort: List[Dict] = None,
+        **options: Any,
+    ) -> Dict[str, Any]:
         params = options.copy()
         if isinstance(query, str):
             params.update({"query": query})
         else:
             params.update({"message_filter_conditions": query})
-        params.update(
-            {"filter_conditions": filter_conditions, "sort": self.normalize_sort(sort)}
-        )
+
+        params.update({"filter_conditions": filter_conditions})
+        if sort:
+            params.update({"sort": self.normalize_sort(sort)})
+
         return params
 
-    def verify_webhook(self, request_body, x_signature):
+    def verify_webhook(self, request_body: bytes, x_signature: str) -> bool:
         """
         Verify the signature added to a webhook event
 
@@ -69,35 +85,49 @@ class StreamChatInterface(abc.ABC):
         return signature == x_signature
 
     @abc.abstractmethod
-    def update_app_settings(self, **settings):
+    def update_app_settings(
+        self, **settings: Any
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         pass
 
     @abc.abstractmethod
-    def get_app_settings(self):
+    def get_app_settings(self) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         pass
 
     @abc.abstractmethod
-    def update_users(self, users):
+    def update_users(
+        self, users: List[Dict]
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         pass
 
     @abc.abstractmethod
-    def update_user(self, user):
+    def update_user(
+        self, user: Dict
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         pass
 
     @abc.abstractmethod
-    def update_users_partial(self, updates):
+    def update_users_partial(
+        self, updates: List[Dict]
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         pass
 
     @abc.abstractmethod
-    def update_user_partial(self, update):
+    def update_user_partial(
+        self, update: Dict
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         pass
 
     @abc.abstractmethod
-    def delete_user(self, user_id, **options):
+    def delete_user(
+        self, user_id: str, **options: Any
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         pass
 
     @abc.abstractmethod
-    def delete_users(self, user_ids, delete_type, **options):
+    def delete_users(
+        self, user_ids: Iterable[str], delete_type: str, **options: Any
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Delete users asynchronously
 
@@ -109,55 +139,81 @@ class StreamChatInterface(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def deactivate_user(self, user_id, **options):
+    def deactivate_user(
+        self, user_id: str, **options: Any
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         pass
 
     @abc.abstractmethod
-    def reactivate_user(self, user_id, **options):
+    def reactivate_user(
+        self, user_id: str, **options: Any
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         pass
 
     @abc.abstractmethod
-    def export_user(self, user_id, **options):
+    def export_user(
+        self, user_id: str, **options: Any
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         pass
 
     @abc.abstractmethod
-    def ban_user(self, target_id, **options):
+    def ban_user(
+        self, target_id: str, **options: Any
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         pass
 
     @abc.abstractmethod
-    def shadow_ban(self, target_id, **options):
+    def shadow_ban(
+        self, target_id: str, **options: Any
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         pass
 
     @abc.abstractmethod
-    def remove_shadow_ban(self, target_id, **options):
+    def remove_shadow_ban(
+        self, target_id: str, **options: Any
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         pass
 
     @abc.abstractmethod
-    def unban_user(self, target_id, **options):
+    def unban_user(
+        self, target_id: str, **options: Any
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         pass
 
     @abc.abstractmethod
-    def flag_message(self, target_id, **options):
+    def flag_message(
+        self, target_id: str, **options: Any
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         pass
 
     @abc.abstractmethod
-    def unflag_message(self, target_id, **options):
+    def unflag_message(
+        self, target_id: str, **options: Any
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         pass
 
     @abc.abstractmethod
-    def query_message_flags(self, filter_conditions, **options):
+    def query_message_flags(
+        self, filter_conditions: Dict, **options: Any
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         pass
 
     @abc.abstractmethod
-    def flag_user(self, target_id, **options):
+    def flag_user(
+        self, target_id: str, **options: Any
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         pass
 
     @abc.abstractmethod
-    def unflag_user(self, target_id, **options):
+    def unflag_user(
+        self, target_id: str, **options: Any
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         pass
 
     @abc.abstractmethod
-    def mute_user(self, target_id, user_id, **options):
+    def mute_user(
+        self, target_id: str, user_id: str, **options: Any
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Create a mute
 
@@ -169,7 +225,9 @@ class StreamChatInterface(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def unmute_user(self, target_id, user_id):
+    def unmute_user(
+        self, target_id: str, user_id: str
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Removes a mute
 
@@ -181,59 +239,85 @@ class StreamChatInterface(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def mark_all_read(self, user_id):
+    def mark_all_read(
+        self, user_id: str
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         pass
 
     @abc.abstractmethod
-    def pin_message(self, message_id, user_id, expiration=None):
+    def pin_message(
+        self, message_id: str, user_id: str, expiration: int = None
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         pass
 
     @abc.abstractmethod
-    def unpin_message(self, message_id, user_id):
+    def unpin_message(
+        self, message_id: str, user_id: str
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         pass
 
     @abc.abstractmethod
-    def update_message(self, message):
+    def update_message(
+        self, message: Dict
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         pass
 
     @abc.abstractmethod
-    def update_message_partial(self, message_id, updates, user_id, **options):
+    def update_message_partial(
+        self, message_id: str, updates: Dict, user_id: str, **options: Any
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         pass
 
     @abc.abstractmethod
-    def delete_message(self, message_id, **options):
+    def delete_message(
+        self, message_id: str, **options: Any
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         pass
 
     @abc.abstractmethod
-    def get_message(self, message_id):
+    def get_message(
+        self, message_id: str
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         pass
 
     @abc.abstractmethod
-    def query_users(self, filter_conditions, sort=None, **options):
+    def query_users(
+        self, filter_conditions: Dict, sort: List[Dict] = None, **options: Any
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         pass
 
     @abc.abstractmethod
-    def query_channels(self, filter_conditions, sort=None, **options):
+    def query_channels(
+        self, filter_conditions: Dict, sort: List[Dict] = None, **options: Any
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         pass
 
     @abc.abstractmethod
-    def create_channel_type(self, data):
+    def create_channel_type(
+        self, data: Dict
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         pass
 
     @abc.abstractmethod
-    def get_channel_type(self, channel_type):
+    def get_channel_type(
+        self, channel_type: str
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         pass
 
     @abc.abstractmethod
-    def list_channel_types(self):
+    def list_channel_types(self) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         pass
 
     @abc.abstractmethod
-    def update_channel_type(self, channel_type, **settings):
+    def update_channel_type(
+        self, channel_type: str, **settings: Any
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         pass
 
     @abc.abstractmethod
-    def delete_channel_type(self, channel_type):
+    def delete_channel_type(
+        self, channel_type: str
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Delete a type of channel
 
@@ -243,7 +327,9 @@ class StreamChatInterface(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def channel(self, channel_type, channel_id=None, data=None):
+    def channel(
+        self, channel_type: str, channel_id: str = None, data: Dict = None
+    ) -> TChannel:
         """
         Creates a channel object
 
@@ -255,31 +341,43 @@ class StreamChatInterface(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def delete_channels(self, cids, **options):
+    def delete_channels(
+        self, cids: Iterable[str], **options: Any
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         pass
 
     @abc.abstractmethod
-    def list_commands(self):
+    def list_commands(self) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         pass
 
     @abc.abstractmethod
-    def create_command(self, data):
+    def create_command(
+        self, data: Dict
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         pass
 
     @abc.abstractmethod
-    def delete_command(self, name):
+    def delete_command(
+        self, name: str
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         pass
 
     @abc.abstractmethod
-    def get_command(self, name):
+    def get_command(
+        self, name: str
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         pass
 
     @abc.abstractmethod
-    def update_command(self, name, **settings):
+    def update_command(
+        self, name: str, **settings: Any
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         pass
 
     @abc.abstractmethod
-    def add_device(self, device_id, push_provider, user_id):
+    def add_device(
+        self, device_id: str, push_provider: str, user_id: str
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Add a device to a user
 
@@ -291,7 +389,9 @@ class StreamChatInterface(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def delete_device(self, device_id, user_id):
+    def delete_device(
+        self, device_id: str, user_id: str
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Delete a device for a user
 
@@ -302,7 +402,9 @@ class StreamChatInterface(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def get_devices(self, user_id):
+    def get_devices(
+        self, user_id: str
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Get the list of devices for a user
 
@@ -312,7 +414,14 @@ class StreamChatInterface(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def get_rate_limits(self, server_side, android, ios, web, endpoints):
+    def get_rate_limits(
+        self,
+        server_side: bool = False,
+        android: bool = False,
+        ios: bool = False,
+        web: bool = False,
+        endpoints: Iterable[str] = None,
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Get rate limit quotas and usage.
         If no params are toggled, all limits for all endpoints are returned.
@@ -326,15 +435,25 @@ class StreamChatInterface(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def search(self, filter_conditions, query, **options):
+    def search(
+        self,
+        filter_conditions: Dict,
+        query: Union[str, Dict],
+        sort: List[Dict] = None,
+        **options: Any,
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         pass
 
     @abc.abstractmethod
-    def send_file(self, uri, url, name, user, content_type=None):
+    def send_file(
+        self, uri: str, url: str, name: str, user: Dict, content_type: str = None
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         pass
 
     @abc.abstractmethod
-    def create_blocklist(self, name, words):
+    def create_blocklist(
+        self, name: str, words: Iterable[str]
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Create a blocklist
 
@@ -345,7 +464,7 @@ class StreamChatInterface(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def list_blocklists(self):
+    def list_blocklists(self) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         List blocklists
 
@@ -354,7 +473,9 @@ class StreamChatInterface(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def get_blocklist(self, name):
+    def get_blocklist(
+        self, name: str
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """Get a blocklist by name
 
         :param name: the name of the blocklist
@@ -363,7 +484,9 @@ class StreamChatInterface(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def update_blocklist(self, name, words):
+    def update_blocklist(
+        self, name: str, words: Iterable[str]
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Update a blocklist
 
@@ -374,7 +497,9 @@ class StreamChatInterface(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def delete_blocklist(self, name):
+    def delete_blocklist(
+        self, name: str
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """Delete a blocklist by name
 
         :param: the name of the blocklist
@@ -383,7 +508,9 @@ class StreamChatInterface(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def check_sqs(self, sqs_key=None, sqs_secret=None, sqs_url=None):
+    def check_sqs(
+        self, sqs_key: str = None, sqs_secret: str = None, sqs_url: str = None
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Check SQS Push settings
 
@@ -397,7 +524,9 @@ class StreamChatInterface(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def get_permission(self, name):
+    def get_permission(
+        self, name: str
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Get the definition for a permission
 
@@ -406,7 +535,9 @@ class StreamChatInterface(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def create_permission(self, permission):
+    def create_permission(
+        self, permission: Dict
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Create a custom permission
 
@@ -415,7 +546,9 @@ class StreamChatInterface(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def update_permission(self, name, permission):
+    def update_permission(
+        self, name: str, permission: Dict
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Update a custom permission
 
@@ -425,7 +558,9 @@ class StreamChatInterface(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def delete_permission(self, name):
+    def delete_permission(
+        self, name: str
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Delete a custom permission
 
@@ -434,14 +569,16 @@ class StreamChatInterface(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def list_permissions(self):
+    def list_permissions(self) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         List all permissions of the app
         """
         pass
 
     @abc.abstractmethod
-    def create_role(self, name):
+    def create_role(
+        self, name: str
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Create a custom role
 
@@ -450,7 +587,9 @@ class StreamChatInterface(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def delete_role(self, name):
+    def delete_role(
+        self, name: str
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Delete a custom role
 
@@ -459,126 +598,160 @@ class StreamChatInterface(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def list_roles(self):
+    def list_roles(self) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         List all roles of the app
         """
         pass
 
     @abc.abstractmethod
-    def create_segment(self, segment):
+    def create_segment(
+        self, segment: Dict
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Create a segment
         """
         pass
 
     @abc.abstractmethod
-    def get_segment(self, segment_id):
+    def get_segment(
+        self, segment_id: str
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Get a segment by id
         """
         pass
 
     @abc.abstractmethod
-    def list_segments(self, **params):
+    def list_segments(
+        self, **params: Any
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         List segments
         """
         pass
 
     @abc.abstractmethod
-    def update_segment(self, segment_id, data):
+    def update_segment(
+        self, segment_id: str, data: Dict
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Update a segment by id
         """
         pass
 
     @abc.abstractmethod
-    def delete_segment(self, segment_id):
+    def delete_segment(
+        self, segment_id: str
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Delete a segment by id
         """
         pass
 
     @abc.abstractmethod
-    def create_campaign(self, campaign):
+    def create_campaign(
+        self, campaign: Dict
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Create a campaign
         """
         pass
 
     @abc.abstractmethod
-    def get_campaign(self, campaign_id):
+    def get_campaign(
+        self, campaign_id: str
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Get a campaign by id
         """
         pass
 
     @abc.abstractmethod
-    def list_campaigns(self, **params):
+    def list_campaigns(
+        self, **params: Any
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         List campaigns
         """
         pass
 
     @abc.abstractmethod
-    def update_campaign(self, campaign_id, data):
+    def update_campaign(
+        self, campaign_id: str, data: Dict
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Update a campaign
         """
         pass
 
     @abc.abstractmethod
-    def delete_campaign(self, campaign_id):
+    def delete_campaign(
+        self, campaign_id: str
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Delete a campaign by id
         """
         pass
 
     @abc.abstractmethod
-    def schedule_campaign(self, campaign_id, send_at=None):
+    def schedule_campaign(
+        self, campaign_id: str, send_at: int = None
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Schedule a campaign at given time
         """
         pass
 
     @abc.abstractmethod
-    async def stop_campaign(self, campaign_id):
+    def stop_campaign(
+        self, campaign_id: str
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Stop a in progress campaign
         """
         pass
 
     @abc.abstractmethod
-    def resume_campaign(self, campaign_id):
+    def resume_campaign(
+        self, campaign_id: str
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Resume a stopped campaign
         """
         pass
 
     @abc.abstractmethod
-    def test_campaign(self, campaign_id, users):
+    def test_campaign(
+        self, campaign_id: str, users: Iterable[str]
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Trigger a test send of the given campaing to given users
         """
         pass
 
     @abc.abstractmethod
-    def revoke_tokens(self, since):
+    def revoke_tokens(
+        self, since: Union[str, datetime.datetime]
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Revoke tokens for an application issued since
         """
         pass
 
     @abc.abstractmethod
-    def revoke_user_token(self, user_id, since):
+    def revoke_user_token(
+        self, user_id: str, before: Union[str, datetime.datetime]
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Revoke tokens for a user issued since
         """
         pass
 
     @abc.abstractmethod
-    def revoke_users_token(self, user_ids, since):
+    def revoke_users_token(
+        self, user_ids: Iterable[str], before: Union[str, datetime.datetime]
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Revoke tokens for users issued since
         """
@@ -586,30 +759,64 @@ class StreamChatInterface(abc.ABC):
 
     @abc.abstractmethod
     def export_channel(
-        self, channel_type, channel_id, messages_since=None, messages_until=None
-    ):
+        self,
+        channel_type: str,
+        channel_id: str,
+        messages_since: Union[str, datetime.datetime] = None,
+        messages_until: Union[str, datetime.datetime] = None,
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Requests a channel export
         """
         pass
 
     @abc.abstractmethod
-    def export_channels(self, channels):
+    def export_channels(
+        self, channels: Iterable[Dict]
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Requests a channels export
         """
         pass
 
     @abc.abstractmethod
-    def get_export_channel_status(self, task_id):
+    def get_export_channel_status(
+        self, task_id: str
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Retrieves status of export
         """
         pass
 
     @abc.abstractmethod
-    def get_task(self, task_id):
+    def get_task(
+        self, task_id: str
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Retrieves status of task
         """
+        pass
+
+    #####################
+    #  Private methods  #
+    #####################
+
+    @abc.abstractmethod
+    def get(self, relative_url: str, params: Dict = None) -> Any:
+        pass
+
+    @abc.abstractmethod
+    def post(self, relative_url: str, params: Dict = None, data: Any = None) -> Any:
+        pass
+
+    @abc.abstractmethod
+    def delete(self, relative_url: str, params: Dict = None) -> Any:
+        pass
+
+    @abc.abstractmethod
+    def patch(self, relative_url: str, params: Dict = None, data: Any = None) -> Any:
+        pass
+
+    @abc.abstractmethod
+    def put(self, relative_url: str, params: Dict = None, data: Any = None) -> Any:
         pass

--- a/stream_chat/base/exceptions.py
+++ b/stream_chat/base/exceptions.py
@@ -1,4 +1,5 @@
 import json
+from typing import Dict
 
 
 class StreamChannelException(Exception):
@@ -6,20 +7,20 @@ class StreamChannelException(Exception):
 
 
 class StreamAPIException(Exception):
-    def __init__(self, text, status_code):
+    def __init__(self, text: str, status_code: int) -> None:
         self.response_text = text
         self.status_code = status_code
         self.json_response = False
 
         try:
-            parsed_response = json.loads(text)
+            parsed_response: Dict = json.loads(text)
             self.error_code = parsed_response.get("code", "unknown")
             self.error_message = parsed_response.get("message", "unknown")
             self.json_response = True
         except ValueError:
             pass
 
-    def __str__(self):
+    def __str__(self) -> str:
         if self.json_response:
             return f'StreamChat error code {self.error_code}: {self.error_message}"'
         else:

--- a/stream_chat/channel.py
+++ b/stream_chat/channel.py
@@ -1,74 +1,40 @@
 import json
+from typing import Any, Dict, Iterable, List, Union
 
 from stream_chat.base.channel import ChannelInterface, add_user_id
+from stream_chat.types.stream_response import StreamResponse
 
 
 class Channel(ChannelInterface):
-    def send_message(self, message, user_id, **options):
-        """
-        Send a message to this channel
-
-        :param message: the Message object
-        :param user_id: the ID of the user that created the message
-        :return: the Server Response
-        """
+    def send_message(
+        self, message: Dict, user_id: str, **options: Any
+    ) -> StreamResponse:
         payload = {"message": add_user_id(message, user_id), **options}
         return self.client.post(f"{self.url}/message", data=payload)
 
-    def send_event(self, event, user_id):
-        """
-        Send an event on this channel
-
-        :param event: event data, ie {type: 'message.read'}
-        :param user_id: the ID of the user sending the event
-        :return: the Server Response
-        """
+    def send_event(self, event: Dict, user_id: str) -> StreamResponse:
         payload = {"event": add_user_id(event, user_id)}
         return self.client.post(f"{self.url}/event", data=payload)
 
-    def send_reaction(self, message_id, reaction, user_id):
-        """
-        Send a reaction about a message
-
-        :param message_id: the message id
-        :param reaction: the reaction object, ie {type: 'love'}
-        :param user_id: the ID of the user that created the reaction
-        :return: the Server Response
-        """
+    def send_reaction(
+        self, message_id: str, reaction: Dict, user_id: str
+    ) -> StreamResponse:
         payload = {"reaction": add_user_id(reaction, user_id)}
         return self.client.post(f"messages/{message_id}/reaction", data=payload)
 
-    def delete_reaction(self, message_id, reaction_type, user_id):
-        """
-        Delete a reaction by user and type
-
-        :param message_id: the id of the message from which te remove the reaction
-        :param reaction_type: the type of reaction that should be removed
-        :param user_id: the id of the user
-        :return: the Server Response
-        """
+    def delete_reaction(
+        self, message_id: str, reaction_type: str, user_id: str
+    ) -> StreamResponse:
         return self.client.delete(
             f"messages/{message_id}/reaction/{reaction_type}",
             params={"user_id": user_id},
         )
 
-    def create(self, user_id):
-        """
-        Create the channel
-
-        :param user_id: the ID of the user creating this channel
-        :return:
-        """
+    def create(self, user_id: str) -> StreamResponse:
         self.custom_data["created_by"] = {"id": user_id}
         return self.query(watch=False, state=False, presence=False)
 
-    def query(self, **options):
-        """
-        Query the API for this channel, get messages, members or other channel fields
-
-        :param options: the query options, check docs on https://getstream.io/chat/docs/
-        :return: Returns a query response
-        """
+    def query(self, **options: Any) -> StreamResponse:
         payload = {"state": True, "data": self.custom_data, **options}
 
         url = f"channels/{self.channel_type}"
@@ -78,26 +44,13 @@ class Channel(ChannelInterface):
         state = self.client.post(f"{url}/query", data=payload)
 
         if self.id is None:
-            self.id = state["channel"]["id"]
+            self.id: str = state["channel"]["id"]
 
         return state
 
-    def query_members(self, filter_conditions, sort=None, **options):
-        """
-        Query the API for this channel to filter, sort and paginate its members efficiently.
-
-        :param filter_conditions: filters, checks docs on https://getstream.io/chat/docs/
-        :param sort: sorting field and direction slice, check docs on https://getstream.io/chat/docs/
-        :param options: pagination or members based channel searching details
-        :return: Returns members response
-
-        eg.
-        channel.query_members(filter_conditions={"name": "tommaso"},
-                              sort=[{"created_at": -1}, {"updated_at": 1}],
-                              offset=0,
-                              limit=10)
-        """
-
+    def query_members(
+        self, filter_conditions: Dict, sort: List[Dict] = None, **options: Any
+    ) -> List[Dict]:
         payload = {
             "id": self.id,
             "type": self.channel_type,
@@ -105,219 +58,130 @@ class Channel(ChannelInterface):
             "sort": self.client.normalize_sort(sort),
             **options,
         }
-        response = self.client.get("members", params={"payload": json.dumps(payload)})
+        response: StreamResponse = self.client.get(
+            "members", params={"payload": json.dumps(payload)}
+        )
         return response["members"]
 
-    def update(self, channel_data, update_message=None):
-        """
-        Edit the channel's custom properties
-
-        :param channel_data: the object to update the custom properties of this channel with
-        :param update_message: optional update message
-        :return: The server response
-        """
+    def update(self, channel_data: Dict, update_message: Dict = None) -> StreamResponse:
         payload = {"data": channel_data, "message": update_message}
         return self.client.post(self.url, data=payload)
 
-    def update_partial(self, to_set=None, to_unset=None):
-        """
-        Update channel partially
-
-        :param to_set: a dictionary of key/value pairs to set or to override
-        :param to_unset: a list of keys to clear
-        """
+    def update_partial(
+        self, to_set: Dict = None, to_unset: Iterable[str] = None
+    ) -> StreamResponse:
         payload = {"set": to_set or {}, "unset": to_unset or []}
         return self.client.patch(self.url, data=payload)
 
-    def delete(self):
-        """
-        Delete the channel. Messages are permanently removed.
-
-        :return: The server response
-        """
+    def delete(self) -> StreamResponse:
         return self.client.delete(self.url)
 
-    def truncate(self, **options):
-        """
-        Removes all messages from the channel
-
-        :param options: the query options, check docs on https://getstream.io/chat/docs/python/channel_delete/?language=python#truncating-a-channel
-        :return: The server response
-        """
+    def truncate(self, **options: Any) -> StreamResponse:
         return self.client.post(f"{self.url}/truncate", data=options)
 
-    def add_members(self, members, message=None, **options):
-        """
-        Adds members to the channel
-
-        :param members: member objects to add
-        :param message: An optional to show
-        :param options: additional options such as hide_history
-        :return:
-        """
+    def add_members(
+        self, members: Iterable[Dict], message: Dict = None, **options: Any
+    ) -> StreamResponse:
         payload = {"add_members": members, "message": message, **options}
         return self.client.post(self.url, data=payload)
 
-    def assign_roles(self, members, message=None):
-        """
-        Assigns new roles to specified channel members
-
-        :param members: member objects with role information
-        :param message: An optional to show
-        :return:
-        """
+    def assign_roles(
+        self, members: Iterable[Dict], message: Dict = None
+    ) -> StreamResponse:
         return self.client.post(
             self.url, data={"assign_roles": members, "message": message}
         )
 
-    def invite_members(self, user_ids, message=None):
-        """
-        invite members to the channel
-
-        :param user_ids: user IDs to invite
-        :param message: An optional to show
-        :return:
-        """
+    def invite_members(
+        self, user_ids: Iterable[str], message: Dict = None
+    ) -> StreamResponse:
         return self.client.post(
             self.url, data={"invites": user_ids, "message": message}
         )
 
-    def add_moderators(self, user_ids, message=None):
-        """
-        Adds moderators to the channel
-
-        :param user_ids: user IDs to add as moderators
-        :param message: An optional to show
-        :return:
-        """
+    def add_moderators(
+        self, user_ids: Iterable[str], message: Dict = None
+    ) -> StreamResponse:
         return self.client.post(
             self.url, data={"add_moderators": user_ids, "message": message}
         )
 
-    def remove_members(self, user_ids, message=None):
-        """
-        Remove members from the channel
-
-        :param user_ids: user IDs to remove from the member list
-        :param message: An optional to show
-        :return:
-        """
+    def remove_members(
+        self, user_ids: Iterable[str], message: Dict = None
+    ) -> StreamResponse:
         return self.client.post(
             self.url, data={"remove_members": user_ids, "message": message}
         )
 
-    def demote_moderators(self, user_ids, message=None):
-        """
-        Demotes moderators from the channel
-
-        :param user_ids: user IDs to demote
-        :param message: An optional to show
-        :return:
-        """
+    def demote_moderators(
+        self, user_ids: Iterable[str], message: Dict = None
+    ) -> StreamResponse:
         return self.client.post(
             self.url, data={"demote_moderators": user_ids, "message": message}
         )
 
-    def mark_read(self, user_id, **data):
-        """
-        Send the mark read event for this user, only works if the `read_events` setting is enabled
-
-        :param user_id: the user ID for the event
-        :param data: additional data, ie {"message_id": last_message_id}
-        :return: The server response
-        """
+    def mark_read(self, user_id: str, **data: Any) -> StreamResponse:
         payload = add_user_id(data, user_id)
         return self.client.post(f"{self.url}/read", data=payload)
 
-    def get_replies(self, parent_id, **options):
-        """
-        List the message replies for a parent message
-
-        :param parent_id: The message parent id, ie the top of the thread
-        :param options: Pagination params, ie {limit:10, id_lte: 10}
-        :return: A response with a list of messages
-        """
+    def get_replies(self, parent_id: str, **options: Any) -> StreamResponse:
         return self.client.get(f"messages/{parent_id}/replies", params=options)
 
-    def get_reactions(self, message_id, **options):
-        """
-        List the reactions, supports pagination
-
-        :param message_id: The message id
-        :param options: Pagination params, ie {"limit":10, "id_lte": 10}
-        :return: A response with a list of reactions
-        """
+    def get_reactions(self, message_id: str, **options: Any) -> StreamResponse:
         return self.client.get(f"messages/{message_id}/reactions", params=options)
 
-    def ban_user(self, target_id, **options):
-        """
-        Bans a user from this channel
-
-        :param target_id: the ID of the user to ban
-        :param options: additional ban options, ie {"timeout": 3600, "reason": "offensive language is not allowed here"}
-        :return: The server response
-        """
-        return self.client.ban_user(
+    def ban_user(self, target_id: str, **options: Any) -> StreamResponse:
+        return self.client.ban_user(  # type: ignore
             target_id, type=self.channel_type, id=self.id, **options
         )
 
-    def unban_user(self, target_id, **options):
-        """
-        Removes the ban for a user on this channel
-
-        :param target_id: the ID of the user to unban
-        :return: The server response
-        """
-        return self.client.unban_user(
+    def unban_user(self, target_id: str, **options: Any) -> StreamResponse:
+        return self.client.unban_user(  # type: ignore
             target_id, type=self.channel_type, id=self.id, **options
         )
 
-    def accept_invite(self, user_id, **data):
+    def accept_invite(self, user_id: str, **data: Any) -> StreamResponse:
         payload = add_user_id(data, user_id)
         payload["accept_invite"] = True
         response = self.client.post(self.url, data=payload)
         self.custom_data = response["channel"]
         return response
 
-    def reject_invite(self, user_id, **data):
+    def reject_invite(self, user_id: str, **data: Any) -> StreamResponse:
         payload = add_user_id(data, user_id)
         payload["reject_invite"] = True
         response = self.client.post(self.url, data=payload)
         self.custom_data = response["channel"]
         return response
 
-    def send_file(self, url, name, user, content_type=None):
-        return self.client.send_file(
+    def send_file(
+        self, url: str, name: str, user: Dict, content_type: str = None
+    ) -> StreamResponse:
+        return self.client.send_file(  # type: ignore
             f"{self.url}/file", url, name, user, content_type=content_type
         )
 
-    def send_image(self, url, name, user, content_type=None):
-        return self.client.send_file(
+    def send_image(
+        self, url: str, name: str, user: Dict, content_type: str = None
+    ) -> StreamResponse:
+        return self.client.send_file(  # type: ignore
             f"{self.url}/image", url, name, user, content_type=content_type
         )
 
-    def delete_file(self, url):
+    def delete_file(self, url: str) -> StreamResponse:
         return self.client.delete(f"{self.url}/file", {"url": url})
 
-    def delete_image(self, url):
+    def delete_image(self, url: str) -> StreamResponse:
         return self.client.delete(f"{self.url}/image", {"url": url})
 
-    def hide(self, user_id):
+    def hide(self, user_id: str) -> StreamResponse:
         return self.client.post(f"{self.url}/hide", data={"user_id": user_id})
 
-    def show(self, user_id):
+    def show(self, user_id: str) -> StreamResponse:
         return self.client.post(f"{self.url}/show", data={"user_id": user_id})
 
-    def mute(self, user_id, expiration=None):
-        """
-        Mutes the channel for the given user for an optional expiration in milliseconds
-
-        :param user_id: the id of the user muting the channel
-        :param expiration: optional expiration in ms. If not given, mute doesn't expire until unmutes
-        :return: The server response
-        """
-
-        params = {
+    def mute(self, user_id: str, expiration: int = None) -> StreamResponse:
+        params: Dict[str, Union[str, int]] = {
             "user_id": user_id,
             "channel_cid": self.cid,
         }
@@ -325,14 +189,7 @@ class Channel(ChannelInterface):
             params["expiration"] = expiration
         return self.client.post("moderation/mute/channel", data=params)
 
-    def unmute(self, user_id):
-        """
-        Unmutes the channel for the given user
-
-        :param user_id: the id of the user unmuting the channel
-        :return: The server response
-        """
-
+    def unmute(self, user_id: str) -> StreamResponse:
         params = {
             "user_id": user_id,
             "channel_cid": self.cid,

--- a/stream_chat/client.py
+++ b/stream_chat/client.py
@@ -1,4 +1,5 @@
 import json
+from typing import Any, Callable, Dict, Iterable, List, Union
 from urllib.parse import urlparse
 from urllib.request import Request, urlopen
 
@@ -8,15 +9,16 @@ import datetime
 from stream_chat.__pkg__ import __version__
 from stream_chat.base.client import StreamChatInterface
 from stream_chat.base.exceptions import StreamAPIException
+from stream_chat.types.stream_response import StreamResponse
 
 from .channel import Channel
 
 
-def get_user_agent():
-    return "stream-python-client-%s" % __version__
+def get_user_agent() -> str:
+    return f"stream-python-client-{__version__}"
 
 
-def get_default_header():
+def get_default_header() -> Dict[str, str]:
     base_headers = {
         "Content-type": "application/json",
         "X-Stream-Client": get_user_agent(),
@@ -25,16 +27,17 @@ def get_default_header():
 
 
 class StreamChat(StreamChatInterface):
-    def __init__(self, api_key, api_secret, timeout=6.0, **options):
+    def __init__(
+        self, api_key: str, api_secret: str, timeout: float = 6.0, **options: Any
+    ):
         super().__init__(
             api_key=api_key, api_secret=api_secret, timeout=timeout, **options
         )
-        s = requests.Session()
-        s.mount("http://", requests.adapters.HTTPAdapter(max_retries=1))
-        s.mount("https://", requests.adapters.HTTPAdapter(max_retries=1))
-        self.session = s
+        self.session = requests.Session()
+        self.session.mount("http://", requests.adapters.HTTPAdapter(max_retries=1))
+        self.session.mount("https://", requests.adapters.HTTPAdapter(max_retries=1))
 
-    def _parse_response(self, response):
+    def _parse_response(self, response: requests.Response) -> StreamResponse:
         try:
             parsed_result = json.loads(response.text) if response.text else {}
         except ValueError:
@@ -43,7 +46,13 @@ class StreamChat(StreamChatInterface):
             raise StreamAPIException(response.text, response.status_code)
         return parsed_result
 
-    def _make_request(self, method, relative_url, params=None, data=None):
+    def _make_request(
+        self,
+        method: Callable[..., requests.Response],
+        relative_url: str,
+        params: Dict = None,
+        data: Any = None,
+    ) -> StreamResponse:
         params = params or {}
         data = data or {}
         serialized = None
@@ -67,79 +76,89 @@ class StreamChat(StreamChatInterface):
         )
         return self._parse_response(response)
 
-    def put(self, relative_url, params=None, data=None):
+    def put(
+        self, relative_url: str, params: Dict = None, data: Any = None
+    ) -> StreamResponse:
         return self._make_request(self.session.put, relative_url, params, data)
 
-    def post(self, relative_url, params=None, data=None):
+    def post(
+        self, relative_url: str, params: Dict = None, data: Any = None
+    ) -> StreamResponse:
         return self._make_request(self.session.post, relative_url, params, data)
 
-    def get(self, relative_url, params=None):
+    def get(self, relative_url: str, params: Dict = None) -> StreamResponse:
         return self._make_request(self.session.get, relative_url, params, None)
 
-    def delete(self, relative_url, params=None):
+    def delete(self, relative_url: str, params: Dict = None) -> StreamResponse:
         return self._make_request(self.session.delete, relative_url, params, None)
 
-    def patch(self, relative_url, params=None, data=None):
+    def patch(
+        self, relative_url: str, params: Dict = None, data: Any = None
+    ) -> StreamResponse:
         return self._make_request(self.session.patch, relative_url, params, data)
 
-    def update_app_settings(self, **settings):
+    def update_app_settings(self, **settings: Any) -> StreamResponse:
         return self.patch("app", data=settings)
 
-    def get_app_settings(self):
+    def get_app_settings(self) -> StreamResponse:
         return self.get("app")
 
-    def update_users(self, users):
+    def update_users(self, users: List[Dict]) -> StreamResponse:
         return self.post("users", data={"users": {u["id"]: u for u in users}})
 
-    def update_user(self, user):
+    def update_user(self, user: Dict) -> StreamResponse:
         return self.update_users([user])
 
-    def update_users_partial(self, updates):
+    def update_users_partial(self, updates: List[Dict]) -> StreamResponse:
         return self.patch("users", data={"users": updates})
 
-    def update_user_partial(self, update):
+    def update_user_partial(self, update: Dict) -> StreamResponse:
         return self.update_users_partial([update])
 
-    def delete_user(self, user_id, **options):
+    def delete_user(self, user_id: str, **options: Any) -> StreamResponse:
         return self.delete(f"users/{user_id}", options)
 
-    def delete_users(self, user_ids, delete_type, **options):
+    def delete_users(
+        self, user_ids: Iterable[str], delete_type: str, **options: Any
+    ) -> StreamResponse:
         return self.post(
             "users/delete", data=dict(options, user=delete_type, user_ids=user_ids)
         )
 
-    def deactivate_user(self, user_id, **options):
+    def deactivate_user(self, user_id: str, **options: Any) -> StreamResponse:
         return self.post(f"users/{user_id}/deactivate", data=options)
 
-    def reactivate_user(self, user_id, **options):
+    def reactivate_user(self, user_id: str, **options: Any) -> StreamResponse:
         return self.post(f"users/{user_id}/reactivate", data=options)
 
-    def export_user(self, user_id, **options):
+    def export_user(self, user_id: str, **options: Any) -> StreamResponse:
         return self.get(f"users/{user_id}/export", options)
 
-    def ban_user(self, target_id, **options):
+    def ban_user(self, target_id: str, **options: Any) -> StreamResponse:
         data = {"target_user_id": target_id, **options}
         return self.post("moderation/ban", data=data)
 
-    def shadow_ban(self, target_id, **options):
+    def shadow_ban(self, target_id: str, **options: Any) -> StreamResponse:
         return self.ban_user(target_id, shadow=True, **options)
 
-    def remove_shadow_ban(self, target_id, **options):
+    def remove_shadow_ban(self, target_id: str, **options: Any) -> StreamResponse:
         return self.unban_user(target_id, shadow=True, **options)
 
-    def unban_user(self, target_id, **options):
+    def unban_user(self, target_id: str, **options: Any) -> StreamResponse:
         params = {"target_user_id": target_id, **options}
         return self.delete("moderation/ban", params)
 
-    def flag_message(self, target_id, **options):
+    def flag_message(self, target_id: str, **options: Any) -> StreamResponse:
         data = {"target_message_id": target_id, **options}
         return self.post("moderation/flag", data=data)
 
-    def unflag_message(self, target_id, **options):
+    def unflag_message(self, target_id: str, **options: Any) -> StreamResponse:
         data = {"target_message_id": target_id, **options}
         return self.post("moderation/unflag", data=data)
 
-    def query_message_flags(self, filter_conditions, **options):
+    def query_message_flags(
+        self, filter_conditions: Dict, **options: Any
+    ) -> StreamResponse:
         params = {
             **options,
             "filter_conditions": filter_conditions,
@@ -148,42 +167,28 @@ class StreamChat(StreamChatInterface):
             "moderation/flags/message", params={"payload": json.dumps(params)}
         )
 
-    def flag_user(self, target_id, **options):
+    def flag_user(self, target_id: str, **options: Any) -> StreamResponse:
         data = {"target_user_id": target_id, **options}
         return self.post("moderation/flag", data=data)
 
-    def unflag_user(self, target_id, **options):
+    def unflag_user(self, target_id: str, **options: Any) -> StreamResponse:
         data = {"target_user_id": target_id, **options}
         return self.post("moderation/unflag", data=data)
 
-    def mute_user(self, target_id, user_id, **options):
-        """
-        Create a mute
-
-        :param target_id: the user getting muted
-        :param user_id: the user muting the target
-        :param options: additional mute options
-        :return:
-        """
+    def mute_user(self, target_id: str, user_id: str, **options: Any) -> StreamResponse:
         data = {"target_id": target_id, "user_id": user_id, **options}
         return self.post("moderation/mute", data=data)
 
-    def unmute_user(self, target_id, user_id):
-        """
-        Removes a mute
-
-        :param target_id: the user getting un-muted
-        :param user_id: the user muting the target
-        :return:
-        """
-
+    def unmute_user(self, target_id: str, user_id: str) -> StreamResponse:
         data = {"target_id": target_id, "user_id": user_id}
         return self.post("moderation/unmute", data=data)
 
-    def mark_all_read(self, user_id):
+    def mark_all_read(self, user_id: str) -> StreamResponse:
         return self.post("channels/read", data={"user": {"id": user_id}})
 
-    def pin_message(self, message_id, user_id, expiration=None):
+    def pin_message(
+        self, message_id: str, user_id: str, expiration: int = None
+    ) -> StreamResponse:
         updates = {
             "set": {
                 "pinned": True,
@@ -192,7 +197,7 @@ class StreamChat(StreamChatInterface):
         }
         return self.update_message_partial(message_id, updates, user_id)
 
-    def unpin_message(self, message_id, user_id):
+    def unpin_message(self, message_id: str, user_id: str) -> StreamResponse:
         updates = {
             "set": {
                 "pinned": False,
@@ -200,138 +205,108 @@ class StreamChat(StreamChatInterface):
         }
         return self.update_message_partial(message_id, updates, user_id)
 
-    def update_message(self, message):
+    def update_message(self, message: Dict) -> StreamResponse:
         if message.get("id") is None:
             raise ValueError("message must have an id")
         return self.post(f"messages/{message['id']}", data={"message": message})
 
-    def update_message_partial(self, message_id, updates, user_id, **options):
+    def update_message_partial(
+        self, message_id: str, updates: Dict, user_id: str, **options: Any
+    ) -> StreamResponse:
         data = updates.copy()
         if user_id:
             data["user"] = {"id": user_id}
         data.update(options)
         return self.put(f"messages/{message_id}", data=data)
 
-    def delete_message(self, message_id, **options):
+    def delete_message(self, message_id: str, **options: Any) -> StreamResponse:
         return self.delete(f"messages/{message_id}", options)
 
-    def get_message(self, message_id):
+    def get_message(self, message_id: str) -> StreamResponse:
         return self.get(f"messages/{message_id}")
 
-    def query_users(self, filter_conditions, sort=None, **options):
-        params = options.copy()
+    def query_users(
+        self, filter_conditions: Dict, sort: List[Dict] = None, **options: Any
+    ) -> StreamResponse:
+        params: Dict = options.copy()
         params.update(
             {"filter_conditions": filter_conditions, "sort": self.normalize_sort(sort)}
         )
         return self.get("users", params={"payload": json.dumps(params)})
 
-    def query_channels(self, filter_conditions, sort=None, **options):
-        params = {"state": True, "watch": False, "presence": False}
+    def query_channels(
+        self, filter_conditions: Dict, sort: List[Dict] = None, **options: Any
+    ) -> StreamResponse:
+        params: Dict[str, Any] = {"state": True, "watch": False, "presence": False}
         params.update(options)
         params.update(
             {"filter_conditions": filter_conditions, "sort": self.normalize_sort(sort)}
         )
         return self.post("channels", data=params)
 
-    def create_channel_type(self, data):
+    def create_channel_type(self, data: Dict) -> StreamResponse:
         if "commands" not in data or not data["commands"]:
             data["commands"] = ["all"]
         return self.post("channeltypes", data=data)
 
-    def get_channel_type(self, channel_type):
+    def get_channel_type(self, channel_type: str) -> StreamResponse:
         return self.get(f"channeltypes/{channel_type}")
 
-    def list_channel_types(self):
+    def list_channel_types(self) -> StreamResponse:
         return self.get("channeltypes")
 
-    def update_channel_type(self, channel_type, **settings):
+    def update_channel_type(self, channel_type: str, **settings: Any) -> StreamResponse:
         return self.put(f"channeltypes/{channel_type}", data=settings)
 
-    def delete_channel_type(self, channel_type):
-        """
-        Delete a type of channel
-
-        :param channel_type: the channel type
-        :return:
-        """
+    def delete_channel_type(self, channel_type: str) -> StreamResponse:
         return self.delete(f"channeltypes/{channel_type}")
 
-    def channel(self, channel_type, channel_id=None, data=None):
-        """
-        Creates a channel object
-
-        :param channel_type: the channel type
-        :param channel_id: the id of the channel
-        :param data: additional data, ie: {"members":[id1, id2, ...]}
-        :return: Channel
-        """
+    def channel(  # type: ignore
+        self, channel_type: str, channel_id: str = None, data: Dict = None
+    ) -> Channel:
         return Channel(self, channel_type, channel_id, data)
 
-    def delete_channels(self, cids, **options):
+    def delete_channels(self, cids: Iterable[str], **options: Any) -> StreamResponse:
         return self.post("channels/delete", data=dict(options, cids=cids))
 
-    def list_commands(self):
+    def list_commands(self) -> StreamResponse:
         return self.get("commands")
 
-    def create_command(self, data):
+    def create_command(self, data: Dict) -> StreamResponse:
         return self.post("commands", data=data)
 
-    def delete_command(self, name):
+    def delete_command(self, name: str) -> StreamResponse:
         return self.delete(f"commands/{name}")
 
-    def get_command(self, name):
+    def get_command(self, name: str) -> StreamResponse:
         return self.get(f"commands/{name}")
 
-    def update_command(self, name, **settings):
+    def update_command(self, name: str, **settings: Any) -> StreamResponse:
         return self.put(f"commands/{name}", data=settings)
 
-    def add_device(self, device_id, push_provider, user_id):
-        """
-        Add a device to a user
-
-        :param device_id: the id of the device
-        :param push_provider: the push provider used (apn or firebase)
-        :param user_id: the id of the user
-        :return:
-        """
+    def add_device(
+        self, device_id: str, push_provider: str, user_id: str
+    ) -> StreamResponse:
         return self.post(
             "devices",
             data={"id": device_id, "push_provider": push_provider, "user_id": user_id},
         )
 
-    def delete_device(self, device_id, user_id):
-        """
-        Delete a device for a user
-
-        :param device_id: the id of the device
-        :param user_id: the id of the user
-        :return:
-        """
+    def delete_device(self, device_id: str, user_id: str) -> StreamResponse:
         return self.delete("devices", {"id": device_id, "user_id": user_id})
 
-    def get_devices(self, user_id):
-        """
-        Get the list of devices for a user
-
-        :param user_id: the id of the user
-        :return: list of devices
-        """
+    def get_devices(self, user_id: str) -> StreamResponse:
         return self.get("devices", {"user_id": user_id})
 
     def get_rate_limits(
-        self, server_side=False, android=False, ios=False, web=False, endpoints=None
-    ):
-        """
-        Get rate limit quotas and usage.
-        If no params are toggled, all limits for all endpoints are returned.
-
-        :param server_side: if true, show server_side limits.
-        :param android: if true, show android limits.
-        :param ios: if true, show ios limits.
-        :param web: if true, show web limits.
-        :param endpoints: restrict returned limits to the given list of endpoints.
-        """
-        params = {}
+        self,
+        server_side: bool = False,
+        android: bool = False,
+        ios: bool = False,
+        web: bool = False,
+        endpoints: Iterable[str] = None,
+    ) -> StreamResponse:
+        params: Dict[str, Any] = {}
         if server_side:
             params["server_side"] = "true"
         if android:
@@ -340,19 +315,27 @@ class StreamChat(StreamChatInterface):
             params["ios"] = "true"
         if web:
             params["web"] = "true"
-        if endpoints is not None and len(endpoints) > 0:
+        if endpoints:
             params["endpoints"] = ",".join(endpoints)
 
         return self.get("rate_limits", params)
 
-    def search(self, filter_conditions, query, sort=None, **options):
+    def search(
+        self,
+        filter_conditions: Dict,
+        query: Union[str, Dict],
+        sort: List[Dict] = None,
+        **options: Any,
+    ) -> StreamResponse:
         if "offset" in options:
             if sort or "next" in options:
                 raise ValueError("cannot use offset with sort or next parameters")
         params = self.create_search_params(filter_conditions, query, sort, **options)
         return self.get("search", params={"payload": json.dumps(params)})
 
-    def send_file(self, uri, url, name, user, content_type=None):
+    def send_file(
+        self, uri: str, url: str, name: str, user: Dict, content_type: str = None
+    ) -> StreamResponse:
         headers = {
             "Authorization": self.auth_token,
             "stream-auth-type": "jwt",
@@ -375,235 +358,111 @@ class StreamChat(StreamChatInterface):
         )
         return self._parse_response(response)
 
-    def create_blocklist(self, name, words):
-        """
-        Create a blocklist
-
-        :param name: the name of the blocklist
-        :param words: list of blocked words
-        :return:
-        """
+    def create_blocklist(self, name: str, words: Iterable[str]) -> StreamResponse:
         return self.post("blocklists", data={"name": name, "words": words})
 
-    def list_blocklists(self):
-        """
-        List blocklists
-
-        :return: list of blocklists
-        """
+    def list_blocklists(self) -> StreamResponse:
         return self.get("blocklists")
 
-    def get_blocklist(self, name):
-        """Get a blocklist by name
-
-        :param name: the name of the blocklist
-        :return: blocklist dict representation
-        """
+    def get_blocklist(self, name: str) -> StreamResponse:
         return self.get(f"blocklists/{name}")
 
-    def update_blocklist(self, name, words):
-        """
-        Update a blocklist
-
-        :param name: the name of the blocklist
-        :param words: the list of blocked words (replaces the current list)
-        :return:
-        """
+    def update_blocklist(self, name: str, words: Iterable[str]) -> StreamResponse:
         return self.put(f"blocklists/{name}", data={"words": words})
 
-    def delete_blocklist(self, name):
-        """Delete a blocklist by name
-
-        :param: the name of the blocklist
-        :return:
-        """
+    def delete_blocklist(self, name: str) -> StreamResponse:
         return self.delete(f"blocklists/{name}")
 
-    def check_sqs(self, sqs_key=None, sqs_secret=None, sqs_url=None):
-        """
-        Check SQS Push settings
-
-        When no parameters are given, the current SQS app settings are used
-
-        :param sqs_key: AWS access key
-        :param sqs_secret: AWS secret key
-        :param sqs_url: URL to SQS queue
-        :return:
-        """
+    def check_sqs(
+        self, sqs_key: str = None, sqs_secret: str = None, sqs_url: str = None
+    ) -> StreamResponse:
         data = {"sqs_key": sqs_key, "sqs_secret": sqs_secret, "sqs_url": sqs_url}
         return self.post("check_sqs", data=data)
 
-    def get_permission(self, id):
-        """
-        Get the definition for a permission
-
-        :param id: ID of the permission
-        """
+    def get_permission(self, id: str) -> StreamResponse:
         return self.get(f"permissions/{id}")
 
-    def create_permission(self, permission):
-        """
-        Create a custom permission
-
-        :param permission: Definition of the permission
-        """
+    def create_permission(self, permission: Dict) -> StreamResponse:
         return self.post("permissions", data=permission)
 
-    def update_permission(self, id, permission):
-        """
-        Update a custom permission
-
-        :param id: ID of the permission
-        :param permission: New definition of the permission
-        """
+    def update_permission(self, id: str, permission: Dict) -> StreamResponse:
         return self.put(f"permissions/{id}", data=permission)
 
-    def delete_permission(self, id):
-        """
-        Delete a custom permission
-
-        :param id: ID of the permission
-        """
+    def delete_permission(self, id: str) -> StreamResponse:
         return self.delete(f"permissions/{id}")
 
-    def list_permissions(self):
-        """
-        List custom permissions of the app
-        """
+    def list_permissions(self) -> StreamResponse:
         return self.get("permissions")
 
-    def create_role(self, name):
-        """
-        Create a custom role
-
-        :param name: Name of the role
-        """
+    def create_role(self, name: str) -> StreamResponse:
         return self.post("roles", data={"name": name})
 
-    def delete_role(self, name):
-        """
-        Delete a custom role
-
-        :param name: Name of the role
-        """
+    def delete_role(self, name: str) -> StreamResponse:
         return self.delete(f"roles/{name}")
 
-    def list_roles(self):
-        """
-        List all roles of the app
-        """
+    def list_roles(self) -> StreamResponse:
         return self.get("roles")
 
-    def create_segment(self, segment):
-        """
-        Create a segment
-        """
+    def create_segment(self, segment: Dict) -> StreamResponse:
         return self.post("segments", data={"segment": segment})
 
-    def get_segment(self, segment_id):
-        """
-        Get a segment by id
-        """
+    def get_segment(self, segment_id: str) -> StreamResponse:
         return self.get(f"segments/{segment_id}")
 
-    def list_segments(self, **params):
-        """
-        List segments
-        """
+    def list_segments(self, **params: Any) -> StreamResponse:
         return self.get("segments", params)
 
-    def update_segment(self, segment_id, data):
-        """
-        Update a segment by id
-        """
+    def update_segment(self, segment_id: str, data: Dict) -> StreamResponse:
         return self.put(f"segments/{segment_id}", data={"segment": data})
 
-    def delete_segment(self, segment_id):
-        """
-        Delete a segment by id
-        """
+    def delete_segment(self, segment_id: str) -> StreamResponse:
         return self.delete(f"segments/{segment_id}")
 
-    def create_campaign(self, campaign):
-        """
-        Create a campaign
-        """
+    def create_campaign(self, campaign: Dict) -> StreamResponse:
         return self.post("campaigns", data={"campaign": campaign})
 
-    def get_campaign(self, campaign_id):
-        """
-        Get a campaign by id
-        """
+    def get_campaign(self, campaign_id: str) -> StreamResponse:
         return self.get(f"campaigns/{campaign_id}")
 
-    def list_campaigns(self, **params):
-        """
-        List campaigns
-        """
+    def list_campaigns(self, **params: Any) -> StreamResponse:
         return self.get("campaigns", params)
 
-    def update_campaign(self, campaign_id, data):
-        """
-        Update a campaign
-        """
+    def update_campaign(self, campaign_id: str, data: Dict) -> StreamResponse:
         return self.put(f"campaigns/{campaign_id}", data={"campaign": data})
 
-    def delete_campaign(self, campaign_id):
-        """
-        Delete a campaign by id
-        """
+    def delete_campaign(self, campaign_id: str) -> StreamResponse:
         return self.delete(f"campaigns/{campaign_id}")
 
-    def schedule_campaign(self, campaign_id, send_at=None):
-        """
-        Schedule a campaign at given time
-        """
+    def schedule_campaign(
+        self, campaign_id: str, send_at: int = None
+    ) -> StreamResponse:
         return self.patch(
             f"campaigns/{campaign_id}/schedule", data={"send_at": send_at}
         )
 
-    def stop_campaign(self, campaign_id):
-        """
-        Stop a in progress campaign
-        """
+    def stop_campaign(self, campaign_id: str) -> StreamResponse:
         return self.patch(f"campaigns/{campaign_id}/stop")
 
-    def resume_campaign(self, campaign_id):
-        """
-        Resume a stopped campaign
-        """
+    def resume_campaign(self, campaign_id: str) -> StreamResponse:
         return self.patch(f"campaigns/{campaign_id}/resume")
 
-    def test_campaign(self, campaign_id, users):
-        """
-        Trigger a test send of the given campaing to given users
-        """
+    def test_campaign(self, campaign_id: str, users: Iterable[str]) -> StreamResponse:
         return self.post(f"campaigns/{campaign_id}/test", data={"users": users})
 
-    def revoke_tokens(self, before):
-        """
-        Revokes tokens for an application
-        :param before: date before which the tokens are to be revoked, to reset pass None
-        """
-        if isinstance(before, datetime.datetime):
-            before = before.isoformat()
+    def revoke_tokens(self, since: Union[str, datetime.datetime]) -> StreamResponse:
+        if isinstance(since, datetime.datetime):
+            since = since.isoformat()
 
-        self.update_app_settings({"revoke_tokens_issued_before": before})
+        return self.update_app_settings(revoke_tokens_issued_before=since)
 
-    def revoke_user_token(self, user_id, before):
-        """
-        Revokes token for a user
-        :param user_id: user_id of user for which the token needs to be revoked
-        :param before: date before which the tokens are to be revoked, to reset pass None
-        """
-        self.revoke_users_token([user_id], before)
+    def revoke_user_token(
+        self, user_id: str, before: Union[str, datetime.datetime]
+    ) -> StreamResponse:
+        return self.revoke_users_token([user_id], before)
 
-    def revoke_users_token(self, user_ids, before):
-        """
-        Revokes tokens for given users
-        :param user_ids: user_ids for user for whom the token needs to be revoked
-        :param before: date before which the tokens are to be revoked, to reset pass None
-        """
+    def revoke_users_token(
+        self, user_ids: Iterable[str], before: Union[str, datetime.datetime]
+    ) -> StreamResponse:
         if isinstance(before, datetime.datetime):
             before = before.isoformat()
 
@@ -612,26 +471,15 @@ class StreamChat(StreamChatInterface):
             updates.append(
                 {"id": user_id, "set": {"revoke_tokens_issued_before": before}}
             )
-        self.update_users_partial(updates)
+        return self.update_users_partial(updates)
 
     def export_channel(
         self,
-        channel_type,
-        channel_id,
-        messages_since=None,
-        messages_until=None,
-    ):
-        """
-        Requests a channel export
-        :param channel_type: channel_type of channel which needs to be exported
-        :param channel_id: channel_id of channel which needs to be exported
-        :param messages_since: RFC-3339 string or datetime to filter messages since that time, optional
-        :param messages_until: RFC-3339 string or datetime to filter messages until that time, optional
-        :type channel_type: str
-        :type channel_id: str
-        :type messages_since: Union[str, datetime.datetime]
-        :type messages_until: Union[str, datetime.datetime]
-        """
+        channel_type: str,
+        channel_id: str,
+        messages_since: Union[str, datetime.datetime] = None,
+        messages_until: Union[str, datetime.datetime] = None,
+    ) -> StreamResponse:
         if isinstance(messages_since, datetime.datetime):
             messages_since = messages_since.isoformat()
         if isinstance(messages_until, datetime.datetime):
@@ -648,25 +496,11 @@ class StreamChat(StreamChatInterface):
             ]
         )
 
-    def export_channels(self, channels):
-        """
-        Requests a channels export
-        :param channels: list of channel's data which need to be exported with keys:
-        - `channel_type`: str
-        - `channel_id`: str
-        - `messages_since` (optional, nullable): str
-        - `messages_until` (optional, nullable): str
-        :type channels: List[Dict[str, str]]
-        """
+    def export_channels(self, channels: Iterable[Dict]) -> StreamResponse:
         return self.post("export_channels", data={"channels": channels})
 
-    def get_export_channel_status(self, task_id):
-        """
-        Retrieves status of export
-        :param task_id: task_id of task which status needs to be retrieved
-        :type task_id: str
-        """
+    def get_export_channel_status(self, task_id: str) -> StreamResponse:
         return self.get(f"export_channels/{task_id}")
 
-    def get_task(self, task_id):
+    def get_task(self, task_id: str) -> StreamResponse:
         return self.get(f"tasks/{task_id}")

--- a/stream_chat/tests/async_chat/conftest.py
+++ b/stream_chat/tests/async_chat/conftest.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+from typing import Dict, List
 import uuid
 
 import pytest
@@ -18,7 +19,7 @@ def pytest_runtest_setup(item):
     if "incremental" in item.keywords:
         previousfailed = getattr(item.parent, "_previousfailed", None)
         if previousfailed is not None:
-            pytest.xfail("previous test failed (%s)" % previousfailed.name)
+            pytest.xfail(f"previous test failed ({previousfailed.name})")
 
 
 def pytest_configure(config):
@@ -46,7 +47,7 @@ async def client():
 
 
 @pytest.fixture(scope="function")
-async def random_user(client):
+async def random_user(client: StreamChatAsync):
     user = {"id": str(uuid.uuid4())}
     response = await client.update_user(user)
     assert "users" in response
@@ -55,7 +56,7 @@ async def random_user(client):
 
 
 @pytest.fixture(scope="function")
-async def server_user(client):
+async def server_user(client: StreamChatAsync):
     user = {"id": str(uuid.uuid4())}
     response = await client.update_user(user)
     assert "users" in response
@@ -64,7 +65,7 @@ async def server_user(client):
 
 
 @pytest.fixture(scope="function")
-async def random_users(client):
+async def random_users(client: StreamChatAsync):
     user1 = {"id": str(uuid.uuid4())}
     user2 = {"id": str(uuid.uuid4())}
     await client.update_users([user1, user2])
@@ -72,7 +73,7 @@ async def random_users(client):
 
 
 @pytest.fixture(scope="function")
-async def channel(client, random_user):
+async def channel(client, random_user: Dict):
     channel = client.channel(
         "messaging", str(uuid.uuid4()), {"test": True, "language": "python"}
     )
@@ -81,7 +82,7 @@ async def channel(client, random_user):
 
 
 @pytest.fixture(scope="function")
-async def command(client):
+async def command(client: StreamChatAsync):
     response = await client.create_command(
         dict(name=str(uuid.uuid4()), description="My command")
     )
@@ -92,8 +93,8 @@ async def command(client):
 
 
 @pytest.fixture(scope="module")
-async def fellowship_of_the_ring(client):
-    members = [
+async def fellowship_of_the_ring(client: StreamChatAsync):
+    members: List[Dict] = [
         {"id": "frodo-baggins", "name": "Frodo Baggins", "race": "Hobbit", "age": 50},
         {"id": "sam-gamgee", "name": "Samwise Gamgee", "race": "Hobbit", "age": 38},
         {"id": "gandalf", "name": "Gandalf the Grey", "race": "Istari"},

--- a/stream_chat/tests/async_chat/test_channel.py
+++ b/stream_chat/tests/async_chat/test_channel.py
@@ -1,14 +1,19 @@
+from typing import Dict, List
 import uuid
 import time
 import pytest
 
+from stream_chat.async_chat.client import StreamChatAsync
+from stream_chat.async_chat.channel import Channel
 from stream_chat.base.exceptions import StreamAPIException
 
 
 @pytest.mark.incremental
 class TestChannel(object):
     @pytest.mark.asyncio
-    async def test_ban_user(self, channel, random_user, server_user):
+    async def test_ban_user(
+        self, channel: Channel, random_user: Dict, server_user: Dict
+    ):
         await channel.ban_user(random_user["id"], user_id=server_user["id"])
         await channel.ban_user(
             random_user["id"],
@@ -19,7 +24,9 @@ class TestChannel(object):
         await channel.unban_user(random_user["id"])
 
     @pytest.mark.asyncio
-    async def test_create_without_id(self, client, random_users):
+    async def test_create_without_id(
+        self, client: StreamChatAsync, random_users: List[Dict]
+    ):
         channel = client.channel(
             "messaging", data={"members": [u["id"] for u in random_users]}
         )
@@ -29,7 +36,7 @@ class TestChannel(object):
         assert channel.id is not None
 
     @pytest.mark.asyncio
-    async def test_send_message_with_options(self, channel, random_user):
+    async def test_send_message_with_options(self, channel: Channel, random_user: Dict):
         response = await channel.send_message(
             {"text": "hi"}, random_user["id"], skip_push=True
         )
@@ -37,13 +44,13 @@ class TestChannel(object):
         assert response["message"]["text"] == "hi"
 
     @pytest.mark.asyncio
-    async def test_send_event(self, channel, random_user):
+    async def test_send_event(self, channel: Channel, random_user: Dict):
         response = await channel.send_event({"type": "typing.start"}, random_user["id"])
         assert "event" in response
         assert response["event"]["type"] == "typing.start"
 
     @pytest.mark.asyncio
-    async def test_send_reaction(self, channel, random_user):
+    async def test_send_reaction(self, channel: Channel, random_user: Dict):
         msg = await channel.send_message({"text": "hi"}, random_user["id"])
         response = await channel.send_reaction(
             msg["message"]["id"], {"type": "love"}, random_user["id"]
@@ -53,7 +60,7 @@ class TestChannel(object):
         assert response["message"]["latest_reactions"][0]["type"] == "love"
 
     @pytest.mark.asyncio
-    async def test_delete_reaction(self, channel, random_user):
+    async def test_delete_reaction(self, channel: Channel, random_user: Dict):
         msg = await channel.send_message({"text": "hi"}, random_user["id"])
         await channel.send_reaction(
             msg["message"]["id"], {"type": "love"}, random_user["id"]
@@ -65,13 +72,13 @@ class TestChannel(object):
         assert len(response["message"]["latest_reactions"]) == 0
 
     @pytest.mark.asyncio
-    async def test_update(self, channel):
+    async def test_update(self, channel: Channel):
         response = await channel.update({"motd": "one apple a day..."})
         assert "channel" in response
         assert response["channel"]["motd"] == "one apple a day..."
 
     @pytest.mark.asyncio
-    async def test_update_partial(self, channel):
+    async def test_update_partial(self, channel: Channel):
         response = await channel.update({"color": "blue", "age": 30})
         assert "channel" in response
         assert response["channel"]["color"] == "blue"
@@ -85,18 +92,18 @@ class TestChannel(object):
         assert "age" not in response["channel"]
 
     @pytest.mark.asyncio
-    async def test_delete(self, channel):
+    async def test_delete(self, channel: Channel):
         response = await channel.delete()
         assert "channel" in response
         assert response["channel"].get("deleted_at") is not None
 
     @pytest.mark.asyncio
-    async def test_truncate(self, channel):
+    async def test_truncate(self, channel: Channel):
         response = await channel.truncate()
         assert "channel" in response
 
     @pytest.mark.asyncio
-    async def test_truncate_with_options(self, channel, random_user):
+    async def test_truncate_with_options(self, channel: Channel, random_user: Dict):
         response = await channel.truncate(
             skip_push=True,
             message={
@@ -107,7 +114,7 @@ class TestChannel(object):
         assert "channel" in response
 
     @pytest.mark.asyncio
-    async def test_add_members(self, channel, random_user):
+    async def test_add_members(self, channel: Channel, random_user: Dict):
         response = await channel.remove_members([random_user["id"]])
         assert len(response["members"]) == 0
 
@@ -116,7 +123,7 @@ class TestChannel(object):
         assert not response["members"][0].get("is_moderator", False)
 
     @pytest.mark.asyncio
-    async def test_add_members_with_options(self, channel, random_user):
+    async def test_add_members_with_options(self, channel: Channel, random_user: Dict):
         response = await channel.remove_members([random_user["id"]])
         assert len(response["members"]) == 0
 
@@ -124,7 +131,7 @@ class TestChannel(object):
         assert len(response["members"]) == 1
 
     @pytest.mark.asyncio
-    async def test_invite_members(self, channel, random_user):
+    async def test_invite_members(self, channel: Channel, random_user: Dict):
         response = await channel.remove_members([random_user["id"]])
         assert len(response["members"]) == 0
 
@@ -133,7 +140,7 @@ class TestChannel(object):
         assert response["members"][0].get("invited", True)
 
     @pytest.mark.asyncio
-    async def test_add_moderators(self, channel, random_user):
+    async def test_add_moderators(self, channel: Channel, random_user: Dict):
         response = await channel.add_moderators([random_user["id"]])
         assert response["members"][0]["is_moderator"]
 
@@ -141,7 +148,7 @@ class TestChannel(object):
         assert not response["members"][0].get("is_moderator", False)
 
     @pytest.mark.asyncio
-    async def test_assign_roles_moderators(self, channel, random_user):
+    async def test_assign_roles_moderators(self, channel: Channel, random_user: Dict):
         member = {"user_id": random_user["id"], "channel_role": "channel_moderator"}
         response = await channel.add_members([member])
         assert len(response["members"]) == 1
@@ -153,13 +160,13 @@ class TestChannel(object):
         assert response["members"][0]["channel_role"] == "channel_member"
 
     @pytest.mark.asyncio
-    async def test_mark_read(self, channel, random_user):
+    async def test_mark_read(self, channel: Channel, random_user: Dict):
         response = await channel.mark_read(random_user["id"])
         assert "event" in response
         assert response["event"]["type"] == "message.read"
 
     @pytest.mark.asyncio
-    async def test_get_replies(self, channel, random_user):
+    async def test_get_replies(self, channel: Channel, random_user: Dict):
         msg = await channel.send_message({"text": "hi"}, random_user["id"])
         response = await channel.get_replies(msg["message"]["id"])
         assert "messages" in response
@@ -181,7 +188,7 @@ class TestChannel(object):
         assert response["messages"][0]["index"] == 7
 
     @pytest.mark.asyncio
-    async def test_get_reactions(self, channel, random_user):
+    async def test_get_reactions(self, channel: Channel, random_user: Dict):
         msg = await channel.send_message({"text": "hi"}, random_user["id"])
         response = await channel.get_reactions(msg["message"]["id"])
 
@@ -205,14 +212,14 @@ class TestChannel(object):
         assert response["reactions"][0]["count"] == 42
 
     @pytest.mark.asyncio
-    async def test_send_and_delete_file(self, channel, random_user):
+    async def test_send_and_delete_file(self, channel: Channel, random_user: Dict):
         url = "helloworld.jpg"
         resp = await channel.send_file(url, "helloworld.jpg", random_user)
         assert "helloworld.jpg" in resp["file"]
         await channel.delete_file(resp["file"])
 
     @pytest.mark.asyncio
-    async def test_send_and_delete_image(self, channel, random_user):
+    async def test_send_and_delete_image(self, channel: Channel, random_user: Dict):
         url = "helloworld.jpg"
         resp = await channel.send_image(
             url, "helloworld.jpg", random_user, content_type="image/jpeg"
@@ -221,7 +228,9 @@ class TestChannel(object):
         await channel.delete_image(resp["file"])
 
     @pytest.mark.asyncio
-    async def test_channel_hide_show(self, client, channel, random_users):
+    async def test_channel_hide_show(
+        self, client: StreamChatAsync, channel: Channel, random_users: List[Dict]
+    ):
         # setup
         await channel.add_members([u["id"] for u in random_users])
         # verify
@@ -263,7 +272,7 @@ class TestChannel(object):
         assert len(response["channels"]) == 1
 
     @pytest.mark.asyncio
-    async def test_invites(self, client, channel):
+    async def test_invites(self, client: StreamChatAsync, channel: Channel):
         members = ["john", "paul", "george", "pete", "ringo", "eric"]
         await client.update_users([{"id": m} for m in members])
         channel = client.channel(
@@ -293,7 +302,7 @@ class TestChannel(object):
         await channel.reject_invite("eric")
 
     @pytest.mark.asyncio
-    async def test_query_members(self, client, channel):
+    async def test_query_members(self, client: StreamChatAsync, channel: Channel):
         members = ["paul", "george", "john", "jessica", "john2"]
         await client.update_users([{"id": m, "name": m} for m in members])
         for member in members:
@@ -311,7 +320,9 @@ class TestChannel(object):
         assert response[1]["user"]["id"] == "john2"
 
     @pytest.mark.asyncio
-    async def test_mute_unmute(self, client, channel, random_users):
+    async def test_mute_unmute(
+        self, client: StreamChatAsync, channel: Channel, random_users: List[Dict]
+    ):
         user_id = random_users[0]["id"]
         response = await channel.mute(user_id, expiration=30000)
         assert "channel_mute" in response
@@ -332,7 +343,9 @@ class TestChannel(object):
         assert len(response["channels"]) == 0
 
     @pytest.mark.asyncio
-    async def test_export_channel_status(self, client, channel):
+    async def test_export_channel_status(
+        self, client: StreamChatAsync, channel: Channel
+    ):
         with pytest.raises(StreamAPIException, match=r".*Can't find task.*"):
             await client.get_export_channel_status(str(uuid.uuid4()))
 
@@ -340,7 +353,9 @@ class TestChannel(object):
             await client.export_channel("messaging", str(uuid.uuid4()))
 
     @pytest.mark.asyncio
-    async def test_export_channel(self, client, channel, random_users):
+    async def test_export_channel(
+        self, client: StreamChatAsync, channel: Channel, random_users: List[Dict]
+    ):
         await channel.send_message({"text": "Hey Joni"}, random_users[0]["id"])
 
         resp = await client.export_channel(channel.channel_type, channel.id)

--- a/stream_chat/tests/async_chat/test_client.py
+++ b/stream_chat/tests/async_chat/test_client.py
@@ -1,17 +1,19 @@
 import sys
 from contextlib import suppress
 from operator import itemgetter
+from typing import Dict, List
 
 import jwt
 import pytest
 import time
 import uuid
+from stream_chat.async_chat.channel import Channel
 from stream_chat.async_chat import StreamChatAsync
 from stream_chat.base.exceptions import StreamAPIException
 
 
 class TestClient(object):
-    def test_normalize_sort(self, client):
+    def test_normalize_sort(self, client: StreamChatAsync):
         expected = [
             {"field": "field1", "direction": 1},
             {"field": "field2", "direction": -1},
@@ -33,7 +35,7 @@ class TestClient(object):
             assert sorted(actual, key=itemgetter("field")) == expected
 
     @pytest.mark.asyncio
-    async def test_mute_user(self, client, random_users):
+    async def test_mute_user(self, client: StreamChatAsync, random_users: List[Dict]):
         response = await client.mute_user(random_users[0]["id"], random_users[1]["id"])
         assert "mute" in response
         assert "expires" not in response["mute"]
@@ -42,7 +44,9 @@ class TestClient(object):
         await client.unmute_user(random_users[0]["id"], random_users[1]["id"])
 
     @pytest.mark.asyncio
-    async def test_mute_user_with_timeout(self, client, random_users):
+    async def test_mute_user_with_timeout(
+        self, client: StreamChatAsync, random_users: List[Dict]
+    ):
         response = await client.mute_user(
             random_users[0]["id"], random_users[1]["id"], timeout=10
         )
@@ -53,7 +57,9 @@ class TestClient(object):
         await client.unmute_user(random_users[0]["id"], random_users[1]["id"])
 
     @pytest.mark.asyncio
-    async def test_get_message(self, client, channel, random_user):
+    async def test_get_message(
+        self, client: StreamChatAsync, channel: Channel, random_user: Dict
+    ):
         msg_id = str(uuid.uuid4())
         await channel.send_message(
             {"id": msg_id, "text": "helloworld"}, random_user["id"]
@@ -73,28 +79,28 @@ class TestClient(object):
                 await client.get_channel_type("team")
 
     @pytest.mark.asyncio
-    async def test_get_channel_types(self, client):
+    async def test_get_channel_types(self, client: StreamChatAsync):
         response = await client.get_channel_type("team")
         assert "permissions" in response
 
     @pytest.mark.asyncio
-    async def test_list_channel_types(self, client):
+    async def test_list_channel_types(self, client: StreamChatAsync):
         response = await client.list_channel_types()
         assert "channel_types" in response
 
     @pytest.mark.asyncio
-    async def test_update_channel_type(self, client):
+    async def test_update_channel_type(self, client: StreamChatAsync):
         response = await client.update_channel_type("team", commands=["ban", "unban"])
         assert "commands" in response
         assert response["commands"] == ["ban", "unban"]
 
     @pytest.mark.asyncio
-    async def test_get_command(self, client, command):
+    async def test_get_command(self, client: StreamChatAsync, command: Dict):
         response = await client.get_command(command["name"])
         assert command["name"] == response["name"]
 
     @pytest.mark.asyncio
-    async def test_update_command(self, client, command):
+    async def test_update_command(self, client: StreamChatAsync, command: Dict):
         response = await client.update_command(
             command["name"], description="My new command"
         )
@@ -102,7 +108,7 @@ class TestClient(object):
         assert "My new command" == response["command"]["description"]
 
     @pytest.mark.asyncio
-    async def test_list_commands(self, client):
+    async def test_list_commands(self, client: StreamChatAsync):
         response = await client.list_commands()
         assert "commands" in response
 
@@ -113,26 +119,26 @@ class TestClient(object):
         assert payload.get("user_id") == "tommaso"
 
     @pytest.mark.asyncio
-    async def test_get_app_settings(self, client):
+    async def test_get_app_settings(self, client: StreamChatAsync):
         configs = await client.get_app_settings()
         assert "app" in configs
 
     @pytest.mark.asyncio
-    async def test_update_user(self, client):
+    async def test_update_user(self, client: StreamChatAsync):
         user = {"id": str(uuid.uuid4())}
         response = await client.update_user(user)
         assert "users" in response
         assert user["id"] in response["users"]
 
     @pytest.mark.asyncio
-    async def test_update_users(self, client):
+    async def test_update_users(self, client: StreamChatAsync):
         user = {"id": str(uuid.uuid4())}
         response = await client.update_users([user])
         assert "users" in response
         assert user["id"] in response["users"]
 
     @pytest.mark.asyncio
-    async def test_update_user_partial(self, client):
+    async def test_update_user_partial(self, client: StreamChatAsync):
         user_id = str(uuid.uuid4())
         await client.update_user({"id": user_id, "field": "value"})
 
@@ -145,13 +151,13 @@ class TestClient(object):
         assert response["users"][user_id]["field"] == "updated"
 
     @pytest.mark.asyncio
-    async def test_delete_user(self, client, random_user):
+    async def test_delete_user(self, client: StreamChatAsync, random_user: Dict):
         response = await client.delete_user(random_user["id"])
         assert "user" in response
         assert random_user["id"] == response["user"]["id"]
 
     @pytest.mark.asyncio
-    async def test_delete_users(self, client, random_user):
+    async def test_delete_users(self, client: StreamChatAsync, random_user: Dict):
         response = await client.delete_users(
             [random_user["id"]], "hard", conversations="hard", messages="hard"
         )
@@ -166,16 +172,16 @@ class TestClient(object):
 
             time.sleep(1)
 
-        assert False, "task did not succeed"
+        pytest.fail("task did not succeed")
 
     @pytest.mark.asyncio
-    async def test_deactivate_user(self, client, random_user):
+    async def test_deactivate_user(self, client: StreamChatAsync, random_user: Dict):
         response = await client.deactivate_user(random_user["id"])
         assert "user" in response
         assert random_user["id"] == response["user"]["id"]
 
     @pytest.mark.asyncio
-    async def test_reactivate_user(self, client, random_user):
+    async def test_reactivate_user(self, client: StreamChatAsync, random_user: Dict):
         response = await client.deactivate_user(random_user["id"])
         assert "user" in response
         assert random_user["id"] == response["user"]["id"]
@@ -184,17 +190,21 @@ class TestClient(object):
         assert random_user["id"] == response["user"]["id"]
 
     @pytest.mark.asyncio
-    async def test_export_user(self, client, fellowship_of_the_ring):
+    async def test_export_user(self, client: StreamChatAsync, fellowship_of_the_ring):
         response = await client.export_user("gandalf")
         assert "user" in response
         assert response["user"]["name"] == "Gandalf the Grey"
 
     @pytest.mark.asyncio
-    async def test_ban_user(self, client, random_user, server_user):
+    async def test_ban_user(
+        self, client: StreamChatAsync, random_user, server_user: Dict
+    ):
         await client.ban_user(random_user["id"], user_id=server_user["id"])
 
     @pytest.mark.asyncio
-    async def test_shadow_ban(self, client, random_user, server_user, channel):
+    async def test_shadow_ban(
+        self, client: StreamChatAsync, random_user, server_user, channel: Channel
+    ):
         msg_id = str(uuid.uuid4())
         response = await channel.send_message(
             {"id": msg_id, "text": "hello world"}, random_user["id"]
@@ -226,25 +236,33 @@ class TestClient(object):
         assert not response["message"]["shadowed"]
 
     @pytest.mark.asyncio
-    async def test_unban_user(self, client, random_user, server_user):
+    async def test_unban_user(
+        self, client: StreamChatAsync, random_user, server_user: Dict
+    ):
         await client.ban_user(random_user["id"], user_id=server_user["id"])
         await client.unban_user(random_user["id"], user_id=server_user["id"])
 
     @pytest.mark.asyncio
-    async def test_flag_user(self, client, random_user, server_user):
+    async def test_flag_user(
+        self, client: StreamChatAsync, random_user, server_user: Dict
+    ):
         await client.flag_user(random_user["id"], user_id=server_user["id"])
 
     @pytest.mark.asyncio
-    async def test_unflag_user(self, client, random_user, server_user):
+    async def test_unflag_user(
+        self, client: StreamChatAsync, random_user, server_user: Dict
+    ):
         await client.flag_user(random_user["id"], user_id=server_user["id"])
         await client.unflag_user(random_user["id"], user_id=server_user["id"])
 
     @pytest.mark.asyncio
-    async def test_mark_all_read(self, client, random_user):
+    async def test_mark_all_read(self, client: StreamChatAsync, random_user: Dict):
         await client.mark_all_read(random_user["id"])
 
     @pytest.mark.asyncio
-    async def test_pin_unpin_message(self, client, channel, random_user):
+    async def test_pin_unpin_message(
+        self, client: StreamChatAsync, channel: Channel, random_user: Dict
+    ):
         msg_id = str(uuid.uuid4())
         response = await channel.send_message(
             {"id": msg_id, "text": "hello world"}, random_user["id"]
@@ -259,7 +277,9 @@ class TestClient(object):
         assert response["message"]["pinned_by"] is None
 
     @pytest.mark.asyncio
-    async def test_update_message(self, client, channel, random_user):
+    async def test_update_message(
+        self, client: StreamChatAsync, channel: Channel, random_user: Dict
+    ):
         msg_id = str(uuid.uuid4())
         response = await channel.send_message(
             {"id": msg_id, "text": "hello world"}, random_user["id"]
@@ -275,7 +295,9 @@ class TestClient(object):
         )
 
     @pytest.mark.asyncio
-    async def test_update_message_partial(self, client, channel, random_user):
+    async def test_update_message_partial(
+        self, client: StreamChatAsync, channel: Channel, random_user: Dict
+    ):
         msg_id = str(uuid.uuid4())
         response = await channel.send_message(
             {"id": msg_id, "text": "hello world"}, random_user["id"]
@@ -290,7 +312,9 @@ class TestClient(object):
         assert response["message"]["awesome"] is True
 
     @pytest.mark.asyncio
-    async def test_delete_message(self, client, channel, random_user):
+    async def test_delete_message(
+        self, client: StreamChatAsync, channel: Channel, random_user: Dict
+    ):
         msg_id = str(uuid.uuid4())
         await channel.send_message(
             {"id": msg_id, "text": "helloworld"}, random_user["id"]
@@ -303,7 +327,9 @@ class TestClient(object):
         await client.delete_message(msg_id, hard=True)
 
     @pytest.mark.asyncio
-    async def test_flag_message(self, client, channel, random_user, server_user):
+    async def test_flag_message(
+        self, client: StreamChatAsync, channel: Channel, random_user, server_user: Dict
+    ):
         msg_id = str(uuid.uuid4())
         await channel.send_message(
             {"id": msg_id, "text": "helloworld"}, random_user["id"]
@@ -311,7 +337,9 @@ class TestClient(object):
         await client.flag_message(msg_id, user_id=server_user["id"])
 
     @pytest.mark.asyncio
-    async def test_query_message_flags(self, client, channel, random_user, server_user):
+    async def test_query_message_flags(
+        self, client: StreamChatAsync, channel: Channel, random_user, server_user: Dict
+    ):
         msg_id = str(uuid.uuid4())
         await channel.send_message(
             {"id": msg_id, "text": "helloworld"}, random_user["id"]
@@ -325,7 +353,9 @@ class TestClient(object):
         assert len(response["flags"]) == 1
 
     @pytest.mark.asyncio
-    async def test_unflag_message(self, client, channel, random_user, server_user):
+    async def test_unflag_message(
+        self, client: StreamChatAsync, channel: Channel, random_user, server_user: Dict
+    ):
         msg_id = str(uuid.uuid4())
         await channel.send_message(
             {"id": msg_id, "text": "helloworld"}, random_user["id"]
@@ -334,13 +364,15 @@ class TestClient(object):
         await client.unflag_message(msg_id, user_id=server_user["id"])
 
     @pytest.mark.asyncio
-    async def test_query_users_young_hobbits(self, client, fellowship_of_the_ring):
+    async def test_query_users_young_hobbits(
+        self, client: StreamChatAsync, fellowship_of_the_ring
+    ):
         response = await client.query_users({"race": {"$eq": "Hobbit"}}, {"age": -1})
         assert len(response["users"]) == 4
         assert [50, 38, 36, 28] == [u["age"] for u in response["users"]]
 
     @pytest.mark.asyncio
-    async def test_devices(self, client, random_user):
+    async def test_devices(self, client: StreamChatAsync, random_user: Dict):
         response = await client.get_devices(random_user["id"])
         assert "devices" in response
         assert len(response["devices"]) == 0
@@ -355,7 +387,7 @@ class TestClient(object):
         assert len(response["devices"]) == 1
 
     @pytest.mark.asyncio
-    async def test_get_rate_limits(self, client):
+    async def test_get_rate_limits(self, client: StreamChatAsync):
         response = await client.get_rate_limits()
         assert "server_side" in response
         assert "android" in response
@@ -388,7 +420,9 @@ class TestClient(object):
 
     @pytest.mark.xfail
     @pytest.mark.asyncio
-    async def test_search_with_sort(self, client, channel, random_user):
+    async def test_search_with_sort(
+        self, client: StreamChatAsync, channel: Channel, random_user: Dict
+    ):
         text = str(uuid.uuid4())
         ids = ["0" + text, "1" + text]
         await channel.send_message(
@@ -415,7 +449,9 @@ class TestClient(object):
         assert ids[0] == response["results"][0]["message"]["id"]
 
     @pytest.mark.asyncio
-    async def test_search(self, client, channel, random_user):
+    async def test_search(
+        self, client: StreamChatAsync, channel: Channel, random_user: Dict
+    ):
         query = "supercalifragilisticexpialidocious"
         await channel.send_message(
             {"text": f"How many syllables are there in {query}?"},
@@ -437,7 +473,9 @@ class TestClient(object):
             assert query not in message["message"]["text"]
 
     @pytest.mark.asyncio
-    async def test_search_message_filters(self, client, channel, random_user):
+    async def test_search_message_filters(
+        self, client: StreamChatAsync, channel: Channel, random_user: Dict
+    ):
         query = "supercalifragilisticexpialidocious"
         await channel.send_message(
             {"text": f"How many syllables are there in {query}?"},
@@ -458,7 +496,7 @@ class TestClient(object):
         assert query in response["results"][0]["message"]["text"]
 
     @pytest.mark.asyncio
-    async def test_search_offset_with_sort(self, client):
+    async def test_search_offset_with_sort(self, client: StreamChatAsync):
         query = "supercalifragilisticexpialidocious"
         with pytest.raises(ValueError):
             await client.search(
@@ -468,7 +506,7 @@ class TestClient(object):
             )
 
     @pytest.mark.asyncio
-    async def test_search_offset_with_next(self, client):
+    async def test_search_offset_with_next(self, client: StreamChatAsync):
         query = "supercalifragilisticexpialidocious"
         with pytest.raises(ValueError):
             await client.search(
@@ -476,7 +514,9 @@ class TestClient(object):
             )
 
     @pytest.mark.asyncio
-    async def test_query_channels_members_in(self, client, fellowship_of_the_ring):
+    async def test_query_channels_members_in(
+        self, client: StreamChatAsync, fellowship_of_the_ring
+    ):
         response = await client.query_channels(
             {"members": {"$in": ["gimli"]}}, {"id": 1}
         )
@@ -485,44 +525,44 @@ class TestClient(object):
         assert len(response["channels"][0]["members"]) == 9
 
     @pytest.mark.asyncio
-    async def test_create_blocklist(self, client):
+    async def test_create_blocklist(self, client: StreamChatAsync):
         await client.create_blocklist(name="Foo", words=["fudge", "heck"])
 
     @pytest.mark.asyncio
-    async def test_list_blocklists(self, client):
+    async def test_list_blocklists(self, client: StreamChatAsync):
         response = await client.list_blocklists()
         assert len(response["blocklists"]) == 2
         blocklist_names = {blocklist["name"] for blocklist in response["blocklists"]}
         assert "Foo" in blocklist_names
 
     @pytest.mark.asyncio
-    async def test_get_blocklist(self, client):
+    async def test_get_blocklist(self, client: StreamChatAsync):
         response = await client.get_blocklist("Foo")
         assert response["blocklist"]["name"] == "Foo"
         assert response["blocklist"]["words"] == ["fudge", "heck"]
 
     @pytest.mark.asyncio
-    async def test_update_blocklist(self, client):
+    async def test_update_blocklist(self, client: StreamChatAsync):
         await client.update_blocklist("Foo", words=["dang"])
         response = await client.get_blocklist("Foo")
         assert response["blocklist"]["words"] == ["dang"]
 
     @pytest.mark.asyncio
-    async def test_delete_blocklist(self, client):
+    async def test_delete_blocklist(self, client: StreamChatAsync):
         await client.delete_blocklist("Foo")
 
     @pytest.mark.asyncio
-    async def test_check_sqs(self, client):
+    async def test_check_sqs(self, client: StreamChatAsync):
         response = await client.check_sqs("key", "secret", "https://foo.com/bar")
         assert response["status"] == "error"
         assert "invalid SQS url" in response["error"]
 
     @pytest.mark.asyncio
     @pytest.mark.skip(reason="slow and flaky due to waits")
-    async def test_custom_permission_and_roles(self, client):
+    async def test_custom_permission_and_roles(self, client: StreamChatAsync):
         id, role = "my-custom-permission", "god"
 
-        def wait():
+        def wait() -> None:
             time.sleep(3)
 
         with suppress(Exception):
@@ -579,7 +619,7 @@ class TestClient(object):
         assert role not in response["roles"]
 
     @pytest.mark.asyncio
-    async def test_delete_channels(self, client, channel):
+    async def test_delete_channels(self, client: StreamChatAsync, channel: Channel):
         response = await client.delete_channels([channel.cid])
         assert "task_id" in response
 
@@ -592,4 +632,4 @@ class TestClient(object):
 
             time.sleep(1)
 
-        assert False, "task did not succeed"
+        pytest.fail("task did not succeed")

--- a/stream_chat/tests/conftest.py
+++ b/stream_chat/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+from typing import Dict, List
 import uuid
 
 import pytest
@@ -17,7 +18,7 @@ def pytest_runtest_setup(item):
     if "incremental" in item.keywords:
         previousfailed = getattr(item.parent, "_previousfailed", None)
         if previousfailed is not None:
-            pytest.xfail("previous test failed (%s)" % previousfailed.name)
+            pytest.xfail(f"previous test failed ({previousfailed.name})")
 
 
 def pytest_configure(config):
@@ -37,7 +38,7 @@ def client():
 
 
 @pytest.fixture(scope="function")
-def random_user(client):
+def random_user(client: StreamChat):
     user = {"id": str(uuid.uuid4())}
     response = client.update_user(user)
     assert "users" in response
@@ -46,7 +47,7 @@ def random_user(client):
 
 
 @pytest.fixture(scope="function")
-def server_user(client):
+def server_user(client: StreamChat):
     user = {"id": str(uuid.uuid4())}
     response = client.update_user(user)
     assert "users" in response
@@ -55,7 +56,7 @@ def server_user(client):
 
 
 @pytest.fixture(scope="function")
-def random_users(client):
+def random_users(client: StreamChat):
     user1 = {"id": str(uuid.uuid4())}
     user2 = {"id": str(uuid.uuid4())}
     client.update_users([user1, user2])
@@ -63,7 +64,7 @@ def random_users(client):
 
 
 @pytest.fixture(scope="function")
-def channel(client, random_user):
+def channel(client: StreamChat, random_user: Dict):
     channel = client.channel(
         "messaging", str(uuid.uuid4()), {"test": True, "language": "python"}
     )
@@ -72,7 +73,7 @@ def channel(client, random_user):
 
 
 @pytest.fixture(scope="function")
-def command(client):
+def command(client: StreamChat):
     response = client.create_command(
         dict(name=str(uuid.uuid4()), description="My command")
     )
@@ -83,8 +84,8 @@ def command(client):
 
 
 @pytest.fixture(scope="module")
-def fellowship_of_the_ring(client):
-    members = [
+def fellowship_of_the_ring(client: StreamChat):
+    members: List[Dict] = [
         {"id": "frodo-baggins", "name": "Frodo Baggins", "race": "Hobbit", "age": 50},
         {"id": "sam-gamgee", "name": "Samwise Gamgee", "race": "Hobbit", "age": 38},
         {"id": "gandalf", "name": "Gandalf the Grey", "race": "Istari"},

--- a/stream_chat/types/stream_response.py
+++ b/stream_chat/types/stream_response.py
@@ -1,0 +1,20 @@
+from typing import Dict
+
+
+class StreamResponse(Dict):
+    pass
+
+
+"""
+Ideally, this would look something like this:
+
+class StreamResponse(TypedDict, allow_extra=True):
+    duration: str
+
+The problem is that Python is not as smart as TypeScript today. `allow_extra` flag
+doesn't exist, only `total=False` which is a bit different.
+
+We'll just inherit from Dict until they solve this problem.
+
+https://github.com/python/mypy/issues/4617
+"""


### PR DESCRIPTION
## Features

- Most importantly added type hints everywhere.
- Enforcing typing during the build with `mypy`
- removed docstrings from derived classes. docstrings are automatically inherited from the abstract class ‼️ no need to declare them twice.
- adding [py.typed file](https://www.python.org/dev/peps/pep-0561/) to the package
- removed unnecessary dependencies
- made testing logic much simpler. it was a bit weird, what was that long thing in setup.py? :)
- fix repository url in setup.py
- don't include test files in the published package ❗ 
- applying more `flake8` rules. Plus fixed two flake8 issues (`__all__` and `assert False`)
- added `flake8-bugbear` package, one of my favourite bug finder 🙂 
- updated release notes: let's upload wheels as well, not just sdists. wheels are generally better.
- added reviewdog

## Future improvements to come
- switch from `setup.py` + `MANIFEST.in` fully over to `pyproject.toml`. we can unify these 3 files into one. I worked a lot with this in the previous company.
- introduce package publishing with GitHub Actions