### PR TITLE
Add rate limit to response, end of Py 3.6 support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+omit = stream_chat/tests/*

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @mahboubii @gumuz
+* @mahboubii @gumuz @peterdeme @ferhatelmas

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @mahboubii @gumuz @peterdeme @ferhatelmas
+* @gumuz @peterdeme @ferhatelmas

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       max-parallel: 1
       matrix:
         python: [3.7, 3.8, 3.9, "3.10"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        python: [3.6, 3.7, 3.8, 3.9, "3.10"]
+        python: [3.7, 3.8, 3.9, "3.10"]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ coverage.xml
 .project
 .pydevproject
 .coverage*
+!.coveragerc
 
 # Rope
 .ropeproject

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ lint:  ## Run linters
 
 lint-fix:
 	black stream_chat
+	isort stream_chat
 
 test:  ## Run tests
 	STREAM_KEY=$(STREAM_KEY) STREAM_SECRET=$(STREAM_SECRET) pytest --cov=stream_chat --cov-report=xml stream_chat/tests

--- a/README.md
+++ b/README.md
@@ -2,11 +2,16 @@
 
 [![build](https://github.com/GetStream/stream-chat-python/workflows/build/badge.svg)](https://github.com/GetStream/stream-chat-python/actions) [![PyPI version](https://badge.fury.io/py/stream-chat.svg)](http://badge.fury.io/py/stream-chat) ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/stream-chat.svg) [![Checked with mypy](http://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)
 
-the official Python API client for [Stream chat](https://getstream.io/chat/) a service for building chat applications.
+---
+> ### :bulb: Major update in v4.0 <
+> The returned response objects are instances of [`StreamResponse`](https://github.com/GetStream/stream-chat-python/blob/master/stream_chat/types/stream_response.py) class. It inherits from `dict`, so it's fully backward compatible. Additionally, it provides other benefits such as rate limit information (`resp.rate_limit()`), response headers (`resp.headers()`) or status code (`resp.status_code()`).
+---
 
-You can sign up for a Stream account at https://getstream.io/chat/get_started/.
+The official Python API client for [Stream chat](https://getstream.io/chat/) a service for building chat applications.
 
-You can use this library to access chat API endpoints server-side, for the client-side integrations (web and mobile) have a look at the Javascript, iOS and Android SDK libraries (https://getstream.io/chat/).
+You can sign up for a Stream account on our [Get Started](https://getstream.io/chat/get_started/) page.
+
+You can use this library to access chat API endpoints server-side, for the client-side integrations (web and mobile) have a look at the Javascript, iOS and Android SDK libraries.
 
 ### Installation
 
@@ -34,6 +39,7 @@ pip install stream-chat
 - User search
 - Channel search
 - Campaign API (alpha - susceptible changes and even won't be available in some regions yet)
+- Rate limit in response
 
 ### Quickstart
 
@@ -57,6 +63,20 @@ def main():
 
     # add a first message to the channel
     channel.send_message({"text": "AMA about kung-fu"}, "chuck")
+
+    # we also expose some response metadata through a custom dictionary
+    resp = chat.deactivate_user("bruce_lee")
+    print(type(resp)) # <class 'stream_chat.types.stream_response.StreamResponse'>
+    print(resp["user"]["id"]) # bruce_lee
+
+    rate_limit = resp.rate_limit()
+    print(f"{rate_limit.limit} / {rate_limit.remaining} / {rate_limit.reset}") # 60 / 59 / 2022-01-06 12:35:00+00:00
+
+    headers = resp.headers()
+    print(headers) # { 'Content-Encoding': 'gzip', 'Content-Length': '33', ... }
+
+    status_code = resp.status_code()
+    print(status_code) # 200
 
 
 if __name__ == '__main__':
@@ -82,6 +102,20 @@ async def main():
 
         # add a first message to the channel
         await channel.send_message({"text": "AMA about kung-fu"}, "chuck")
+
+        # we also expose some response metadata through a custom dictionary
+        resp = await chat.deactivate_user("bruce_lee")
+        print(type(resp)) # <class 'stream_chat.types.stream_response.StreamResponse'>
+        print(resp["user"]["id"]) # bruce_lee
+
+        rate_limit = resp.rate_limit()
+        print(f"{rate_limit.limit} / {rate_limit.remaining} / {rate_limit.reset}") # 60 / 59 / 2022-01-06 12:35:00+00:00
+
+        headers = resp.headers()
+        print(headers) # { 'Content-Encoding': 'gzip', 'Content-Length': '33', ... }
+
+        status_code = resp.status_code()
+        print(status_code) # 200
 
 
 if __name__ == '__main__':

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,11 @@ exclude = '''
 )/
 '''
 
+[tool.isort]
+profile = "black"
+src_paths = ["stream_chat"]
+known_first_party = ["stream_chat"]
+
 [tool.mypy]
 disallow_untyped_defs = true
 disallow_untyped_calls = true

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ tests_require = ["pytest", "pytest-asyncio"]
 ci_require = [
     "black",
     "flake8",
+    "flake8-isort",
     "flake8-bugbear",
     "pytest-cov",
     "mypy",

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     install_requires=install_requires,
     extras_require={"test": tests_require, "ci": ci_require},
     include_package_data=True,
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     classifiers=[
         "Intended Audience :: Developers",
         "Intended Audience :: System Administrators",
@@ -57,7 +57,6 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/stream_chat/__init__.py
+++ b/stream_chat/__init__.py
@@ -1,4 +1,4 @@
-from .client import StreamChat
 from .async_chat import StreamChatAsync
+from .client import StreamChat
 
 __all__ = ["StreamChat", "StreamChatAsync"]

--- a/stream_chat/async_chat/channel.py
+++ b/stream_chat/async_chat/channel.py
@@ -1,7 +1,6 @@
 import json
 from typing import Any, Dict, Iterable, List, Union
 
-
 from stream_chat.base.channel import ChannelInterface, add_user_id
 from stream_chat.types.stream_response import StreamResponse
 

--- a/stream_chat/async_chat/client.py
+++ b/stream_chat/async_chat/client.py
@@ -1,5 +1,5 @@
-import json
 import datetime
+import json
 from types import TracebackType
 from typing import (
     Any,

--- a/stream_chat/async_chat/client.py
+++ b/stream_chat/async_chat/client.py
@@ -56,7 +56,8 @@ class StreamChatAsync(StreamChatInterface, AsyncContextManager):
             raise StreamAPIException(text, response.status)
         if response.status >= 399:
             raise StreamAPIException(text, response.status)
-        return parsed_result
+
+        return StreamResponse(parsed_result, dict(response.headers), response.status)
 
     async def _make_request(
         self,

--- a/stream_chat/base/channel.py
+++ b/stream_chat/base/channel.py
@@ -1,9 +1,9 @@
 import abc
 from typing import Any, Awaitable, Dict, Iterable, List, Union
 
+from stream_chat.base.client import StreamChatInterface
 from stream_chat.base.exceptions import StreamChannelException
 from stream_chat.types.stream_response import StreamResponse
-from stream_chat.base.client import StreamChatInterface
 
 
 class ChannelInterface(abc.ABC):

--- a/stream_chat/base/client.py
+++ b/stream_chat/base/client.py
@@ -3,12 +3,11 @@ import collections
 import datetime
 import hashlib
 import hmac
-from typing import Any, Awaitable, Dict, Iterable, List, Union, TypeVar
+from typing import Any, Awaitable, Dict, Iterable, List, TypeVar, Union
 
 import jwt
 
 from stream_chat.types.stream_response import StreamResponse
-
 
 TChannel = TypeVar("TChannel")
 

--- a/stream_chat/client.py
+++ b/stream_chat/client.py
@@ -44,7 +44,10 @@ class StreamChat(StreamChatInterface):
             raise StreamAPIException(response.text, response.status_code)
         if response.status_code >= 399:
             raise StreamAPIException(response.text, response.status_code)
-        return parsed_result
+
+        return StreamResponse(
+            parsed_result, dict(response.headers), response.status_code
+        )
 
     def _make_request(
         self,

--- a/stream_chat/client.py
+++ b/stream_chat/client.py
@@ -1,10 +1,10 @@
+import datetime
 import json
 from typing import Any, Callable, Dict, Iterable, List, Union
 from urllib.parse import urlparse
 from urllib.request import Request, urlopen
 
 import requests
-import datetime
 
 from stream_chat.__pkg__ import __version__
 from stream_chat.base.client import StreamChatInterface

--- a/stream_chat/tests/async_chat/conftest.py
+++ b/stream_chat/tests/async_chat/conftest.py
@@ -1,7 +1,7 @@
 import asyncio
 import os
-from typing import Dict, List
 import uuid
+from typing import Dict, List
 
 import pytest
 

--- a/stream_chat/tests/async_chat/test_channel.py
+++ b/stream_chat/tests/async_chat/test_channel.py
@@ -1,10 +1,11 @@
-from typing import Dict, List
-import uuid
 import time
+import uuid
+from typing import Dict, List
+
 import pytest
 
-from stream_chat.async_chat.client import StreamChatAsync
 from stream_chat.async_chat.channel import Channel
+from stream_chat.async_chat.client import StreamChatAsync
 from stream_chat.base.exceptions import StreamAPIException
 
 

--- a/stream_chat/tests/async_chat/test_channel.py
+++ b/stream_chat/tests/async_chat/test_channel.py
@@ -9,7 +9,7 @@ from stream_chat.base.exceptions import StreamAPIException
 
 
 @pytest.mark.incremental
-class TestChannel(object):
+class TestChannel:
     @pytest.mark.asyncio
     async def test_ban_user(
         self, channel: Channel, random_user: Dict, server_user: Dict

--- a/stream_chat/tests/async_chat/test_client.py
+++ b/stream_chat/tests/async_chat/test_client.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import sys
 from contextlib import suppress
 from operator import itemgetter
@@ -12,7 +13,7 @@ from stream_chat.async_chat import StreamChatAsync
 from stream_chat.base.exceptions import StreamAPIException
 
 
-class TestClient(object):
+class TestClient:
     def test_normalize_sort(self, client: StreamChatAsync):
         expected = [
             {"field": "field1", "direction": 1},
@@ -673,3 +674,15 @@ class TestClient(object):
             time.sleep(1)
 
         pytest.fail("task did not succeed")
+
+    @pytest.mark.asyncio
+    async def test_stream_response(self, client: StreamChatAsync):
+        resp = await client.get_app_settings()
+
+        assert len(resp.headers()) > 0
+        assert resp.status_code() == 200
+
+        rate_limit = resp.rate_limit()
+        assert rate_limit.limit > 0
+        assert rate_limit.remaining > 0
+        assert type(rate_limit.reset) is datetime

--- a/stream_chat/tests/async_chat/test_client.py
+++ b/stream_chat/tests/async_chat/test_client.py
@@ -1,15 +1,16 @@
-from datetime import datetime
 import sys
+import time
+import uuid
 from contextlib import suppress
+from datetime import datetime
 from operator import itemgetter
 from typing import Dict, List
 
 import jwt
 import pytest
-import time
-import uuid
-from stream_chat.async_chat.channel import Channel
+
 from stream_chat.async_chat import StreamChatAsync
+from stream_chat.async_chat.channel import Channel
 from stream_chat.base.exceptions import StreamAPIException
 
 

--- a/stream_chat/tests/conftest.py
+++ b/stream_chat/tests/conftest.py
@@ -1,6 +1,6 @@
 import os
-from typing import Dict, List
 import uuid
+from typing import Dict, List
 
 import pytest
 

--- a/stream_chat/tests/test_channel.py
+++ b/stream_chat/tests/test_channel.py
@@ -1,12 +1,12 @@
-from typing import Dict, List
-import uuid
 import time
+import uuid
+from typing import Dict, List
 
 import pytest
 
-from stream_chat.channel import Channel
 from stream_chat import StreamChat
 from stream_chat.base.exceptions import StreamAPIException
+from stream_chat.channel import Channel
 
 
 @pytest.mark.incremental

--- a/stream_chat/tests/test_channel.py
+++ b/stream_chat/tests/test_channel.py
@@ -10,7 +10,7 @@ from stream_chat.base.exceptions import StreamAPIException
 
 
 @pytest.mark.incremental
-class TestChannel(object):
+class TestChannel:
     def test_ban_user(self, channel: Channel, random_user, server_user: Dict):
         channel.ban_user(random_user["id"], user_id=server_user["id"])
         channel.ban_user(

--- a/stream_chat/tests/test_client.py
+++ b/stream_chat/tests/test_client.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import sys
 from operator import itemgetter
 from contextlib import suppress
@@ -12,7 +13,7 @@ from stream_chat.channel import Channel
 from stream_chat.base.exceptions import StreamAPIException
 
 
-class TestClient(object):
+class TestClient:
     def test_normalize_sort(self, client: StreamChat):
         expected = [
             {"field": "field1", "direction": 1},
@@ -582,3 +583,14 @@ class TestClient(object):
             time.sleep(1)
 
         pytest.fail("task did not succeed")
+
+    def test_stream_response(self, client: StreamChat):
+        resp = client.get_app_settings()
+
+        assert len(resp.headers()) > 0
+        assert resp.status_code() == 200
+
+        rate_limit = resp.rate_limit()
+        assert rate_limit.limit > 0
+        assert rate_limit.remaining > 0
+        assert type(rate_limit.reset) is datetime

--- a/stream_chat/tests/test_client.py
+++ b/stream_chat/tests/test_client.py
@@ -1,16 +1,17 @@
-from datetime import datetime
 import sys
-from operator import itemgetter
+import time
+import uuid
 from contextlib import suppress
+from datetime import datetime
+from operator import itemgetter
 from typing import Dict, List
 
 import jwt
 import pytest
-import time
-import uuid
+
 from stream_chat import StreamChat
-from stream_chat.channel import Channel
 from stream_chat.base.exceptions import StreamAPIException
+from stream_chat.channel import Channel
 
 
 class TestClient:

--- a/stream_chat/tests/utils.py
+++ b/stream_chat/tests/utils.py
@@ -1,0 +1,37 @@
+import asyncio
+import time
+from typing import Any, Awaitable, Callable
+
+
+def wait_for(condition: Callable[[], Any], timeout: int = 5):
+    start = time.time()
+
+    while True:
+        if timeout < (time.time() - start):
+            raise Exception("Timeout")
+
+        try:
+            if condition():
+                break
+        except Exception:
+            pass
+
+        time.sleep(0.5)
+
+
+async def wait_for_async(
+    condition: Callable[..., Awaitable[Any]], timeout: int = 5, **kwargs
+):
+    start = time.time()
+
+    while True:
+        if timeout < (time.time() - start):
+            raise Exception("Timeout")
+
+        try:
+            if await condition(**kwargs):
+                break
+        except Exception:
+            pass
+
+        await asyncio.sleep(0.5)

--- a/stream_chat/types/rate_limit.py
+++ b/stream_chat/types/rate_limit.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, asdict
+from dataclasses import asdict, dataclass
 from datetime import datetime
 from typing import Dict
 

--- a/stream_chat/types/rate_limit.py
+++ b/stream_chat/types/rate_limit.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass, asdict
+from datetime import datetime
+from typing import Dict
+
+
+@dataclass(frozen=True)
+class RateLimitInfo:
+    limit: int
+    remaining: int
+    reset: datetime
+
+    def as_dict(self) -> Dict[str, int]:
+        return asdict(self)

--- a/stream_chat/types/rate_limit.py
+++ b/stream_chat/types/rate_limit.py
@@ -1,6 +1,5 @@
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from datetime import datetime
-from typing import Dict
 
 
 @dataclass(frozen=True)
@@ -8,6 +7,3 @@ class RateLimitInfo:
     limit: int
     remaining: int
     reset: datetime
-
-    def as_dict(self) -> Dict[str, int]:
-        return asdict(self)


### PR DESCRIPTION
- introduce a new response object: `StreamResponse`
- add ratelimit info, status code, response headers to the response object
- add `isort` code formatter (import statement sorting)
- remove 3.6 support as it's [end of life](https://endoflife.date/python)
- add myself and Ferhat to codeowners
- add ratelimit information to the readme
- stabilized unstable tests