### PR TITLE
ci: fix release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
           TWINE_USERNAME: "__token__"
           TWINE_PASSWORD: "${{ secrets.PYPI_TOKEN }}"
         run: |
-          pip install -q twine==3.7.1
+          pip install -q twine==3.7.1 wheel==0.37.1
           python setup.py sdist bdist_wheel
           twine upload --non-interactive dist/*
 


### PR DESCRIPTION
This fixes the following error:
`error: invalid command 'bdist_wheel'`