### PR TITLE
feat: set keepalive timeout to 59s

### DIFF
--- a/stream_chat/async_chat/client.py
+++ b/stream_chat/async_chat/client.py
@@ -45,7 +45,8 @@ class StreamChatAsync(StreamChatInterface, AsyncContextManager):
             api_key=api_key, api_secret=api_secret, timeout=timeout, **options
         )
         self.session = aiohttp.ClientSession(
-            connector=aiohttp.TCPConnector(keepalive_timeout=3.9)
+            base_url=self.base_url,
+            connector=aiohttp.TCPConnector(keepalive_timeout=59.0),
         )
 
     async def _parse_response(self, response: aiohttp.ClientResponse) -> StreamResponse:
@@ -78,13 +79,11 @@ class StreamChatAsync(StreamChatInterface, AsyncContextManager):
         headers["Authorization"] = self.auth_token
         headers["stream-auth-type"] = "jwt"
 
-        url = f"{self.base_url}/{relative_url}"
-
         if method.__name__ in ["post", "put", "patch"]:
             serialized = json.dumps(data)
 
         async with method(
-            url,
+            "/" + relative_url.lstrip("/"),
             data=serialized,
             headers=headers,
             params=default_params,
@@ -413,7 +412,7 @@ class StreamChatAsync(StreamChatInterface, AsyncContextManager):
         data.add_field("user", json.dumps(user))
         data.add_field("file", content, filename=name, content_type=content_type)
         async with self.session.post(
-            f"{self.base_url}/{uri}",
+            "/" + uri.lstrip("/"),
             params=self.get_default_params(),
             data=data,
             headers=headers,


### PR DESCRIPTION
- set keepalive timeout to 59s
- there's no way to set it in `requests` (`urllib3`), because it doesn't contain [such feature](https://github.com/aio-libs/aiohttp/blob/58da3373a21211bbde21f1393475e73f53a5671d/aiohttp/connector.py#L295)