### PR TITLE
feat: Add type field support on create_blocklist()

### DIFF
--- a/stream_chat/async_chat/client.py
+++ b/stream_chat/async_chat/client.py
@@ -472,8 +472,8 @@ class StreamChatAsync(StreamChatInterface, AsyncContextManager):
         ) as response:
             return await self._parse_response(response)
 
-    async def create_blocklist(self, name: str, words: Iterable[str]) -> StreamResponse:
-        return await self.post("blocklists", data={"name": name, "words": words})
+    async def create_blocklist(self, name: str, words: Iterable[str], blocklist_type: str = None) -> StreamResponse:
+        return await self.post("blocklists", data={"name": name, "words": words, "type": blocklist_type})
 
     async def list_blocklists(self) -> StreamResponse:
         return await self.get("blocklists")

--- a/stream_chat/async_chat/client.py
+++ b/stream_chat/async_chat/client.py
@@ -473,10 +473,10 @@ class StreamChatAsync(StreamChatInterface, AsyncContextManager):
             return await self._parse_response(response)
 
     async def create_blocklist(
-        self, name: str, words: Iterable[str], blocklist_type: str = None
+        self, name: str, words: Iterable[str], type: str = None
     ) -> StreamResponse:
         return await self.post(
-            "blocklists", data={"name": name, "words": words, "type": blocklist_type}
+            "blocklists", data={"name": name, "words": words, "type": type}
         )
 
     async def list_blocklists(self) -> StreamResponse:

--- a/stream_chat/async_chat/client.py
+++ b/stream_chat/async_chat/client.py
@@ -472,8 +472,12 @@ class StreamChatAsync(StreamChatInterface, AsyncContextManager):
         ) as response:
             return await self._parse_response(response)
 
-    async def create_blocklist(self, name: str, words: Iterable[str], blocklist_type: str = None) -> StreamResponse:
-        return await self.post("blocklists", data={"name": name, "words": words, "type": blocklist_type})
+    async def create_blocklist(
+        self, name: str, words: Iterable[str], blocklist_type: str = None
+    ) -> StreamResponse:
+        return await self.post(
+            "blocklists", data={"name": name, "words": words, "type": blocklist_type}
+        )
 
     async def list_blocklists(self) -> StreamResponse:
         return await self.get("blocklists")

--- a/stream_chat/async_chat/client.py
+++ b/stream_chat/async_chat/client.py
@@ -473,7 +473,7 @@ class StreamChatAsync(StreamChatInterface, AsyncContextManager):
             return await self._parse_response(response)
 
     async def create_blocklist(
-        self, name: str, words: Iterable[str], type: str = None
+        self, name: str, words: Iterable[str], type: str = "regular"
     ) -> StreamResponse:
         return await self.post(
             "blocklists", data={"name": name, "words": words, "type": type}

--- a/stream_chat/base/client.py
+++ b/stream_chat/base/client.py
@@ -753,14 +753,14 @@ class StreamChatInterface(abc.ABC):
 
     @abc.abstractmethod
     def create_blocklist(
-        self, name: str, words: Iterable[str], blocklist_type: str = None
+        self, name: str, words: Iterable[str], type: str = None
     ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Create a blocklist
 
         :param name: the name of the blocklist
         :param words: list of blocked words
-        :param blocklist_type: blocklist type
+        :param type: blocklist type
         :return:
         """
         pass

--- a/stream_chat/base/client.py
+++ b/stream_chat/base/client.py
@@ -753,7 +753,7 @@ class StreamChatInterface(abc.ABC):
 
     @abc.abstractmethod
     def create_blocklist(
-        self, name: str, words: Iterable[str], type: str = None
+        self, name: str, words: Iterable[str], type: str = "regular"
     ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Create a blocklist

--- a/stream_chat/base/client.py
+++ b/stream_chat/base/client.py
@@ -753,13 +753,14 @@ class StreamChatInterface(abc.ABC):
 
     @abc.abstractmethod
     def create_blocklist(
-        self, name: str, words: Iterable[str]
+        self, name: str, words: Iterable[str], blocklist_type: str = None
     ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Create a blocklist
 
         :param name: the name of the blocklist
         :param words: list of blocked words
+        :param blocklist_type: blocklist type
         :return:
         """
         pass

--- a/stream_chat/client.py
+++ b/stream_chat/client.py
@@ -456,8 +456,12 @@ class StreamChat(StreamChatInterface):
         )
         return self._parse_response(response)
 
-    def create_blocklist(self, name: str, words: Iterable[str], blocklist_type: str = None) -> StreamResponse:
-        return self.post("blocklists", data={"name": name, "words": words, "type": blocklist_type})
+    def create_blocklist(
+        self, name: str, words: Iterable[str], blocklist_type: str = None
+    ) -> StreamResponse:
+        return self.post(
+            "blocklists", data={"name": name, "words": words, "type": blocklist_type}
+        )
 
     def list_blocklists(self) -> StreamResponse:
         return self.get("blocklists")

--- a/stream_chat/client.py
+++ b/stream_chat/client.py
@@ -457,7 +457,7 @@ class StreamChat(StreamChatInterface):
         return self._parse_response(response)
 
     def create_blocklist(
-        self, name: str, words: Iterable[str], type: str = None
+        self, name: str, words: Iterable[str], type: str = "regular"
     ) -> StreamResponse:
         return self.post(
             "blocklists", data={"name": name, "words": words, "type": type}

--- a/stream_chat/client.py
+++ b/stream_chat/client.py
@@ -456,8 +456,8 @@ class StreamChat(StreamChatInterface):
         )
         return self._parse_response(response)
 
-    def create_blocklist(self, name: str, words: Iterable[str]) -> StreamResponse:
-        return self.post("blocklists", data={"name": name, "words": words})
+    def create_blocklist(self, name: str, words: Iterable[str], blocklist_type: str = None) -> StreamResponse:
+        return self.post("blocklists", data={"name": name, "words": words, "type": blocklist_type})
 
     def list_blocklists(self) -> StreamResponse:
         return self.get("blocklists")

--- a/stream_chat/client.py
+++ b/stream_chat/client.py
@@ -457,10 +457,10 @@ class StreamChat(StreamChatInterface):
         return self._parse_response(response)
 
     def create_blocklist(
-        self, name: str, words: Iterable[str], blocklist_type: str = None
+        self, name: str, words: Iterable[str], type: str = None
     ) -> StreamResponse:
         return self.post(
-            "blocklists", data={"name": name, "words": words, "type": blocklist_type}
+            "blocklists", data={"name": name, "words": words, "type": type}
         )
 
     def list_blocklists(self) -> StreamResponse:

--- a/stream_chat/tests/test_client.py
+++ b/stream_chat/tests/test_client.py
@@ -549,9 +549,7 @@ class TestClient:
         assert len(response["channels"][0]["members"]) == 9
 
     def test_create_blocklist(self, client: StreamChat):
-        client.create_blocklist(
-            name="Foo", words=["fudge", "heck"], blocklist_type="regular"
-        )
+        client.create_blocklist(name="Foo", words=["fudge", "heck"], type="regular")
 
     def test_list_blocklists(self, client: StreamChat):
         response = client.list_blocklists()

--- a/stream_chat/tests/test_client.py
+++ b/stream_chat/tests/test_client.py
@@ -549,7 +549,9 @@ class TestClient:
         assert len(response["channels"][0]["members"]) == 9
 
     def test_create_blocklist(self, client: StreamChat):
-        client.create_blocklist(name="Foo", words=["fudge", "heck"], blocklist_type="regular")
+        client.create_blocklist(
+            name="Foo", words=["fudge", "heck"], blocklist_type="regular"
+        )
 
     def test_list_blocklists(self, client: StreamChat):
         response = client.list_blocklists()

--- a/stream_chat/tests/test_client.py
+++ b/stream_chat/tests/test_client.py
@@ -549,7 +549,7 @@ class TestClient:
         assert len(response["channels"][0]["members"]) == 9
 
     def test_create_blocklist(self, client: StreamChat):
-        client.create_blocklist(name="Foo", words=["fudge", "heck"])
+        client.create_blocklist(name="Foo", words=["fudge", "heck"], blocklist_type="regular")
 
     def test_list_blocklists(self, client: StreamChat):
         response = client.list_blocklists()


### PR DESCRIPTION
# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
For the regex blocklists we need to introduce a new `type` field in the DB to be able to distinguish between regular and regex blocklist (type). Therefore, when creating blocklist through the dashboard/SDK we need to pass the `type` field in the payload. In future, ideally this should support more types.
With the current change I extended the `create_blocklist()` method with an optional parameter that should pass the `type` field to the request payload