### PR TITLE
feat: support all_users & all_sender_channels for segment

### DIFF
--- a/stream_chat/async_chat/client.py
+++ b/stream_chat/async_chat/client.py
@@ -26,6 +26,7 @@ from stream_chat.types.segment import (
     QuerySegmentTargetsOptions,
     SegmentData,
     SegmentType,
+    SegmentUpdatableFields,
 )
 
 if sys.version_info >= (3, 8):
@@ -591,7 +592,7 @@ class StreamChatAsync(StreamChatInterface, AsyncContextManager):
         return await self.post("segments/query", data=payload)
 
     async def update_segment(
-        self, segment_id: str, data: SegmentData
+        self, segment_id: str, data: SegmentUpdatableFields
     ) -> StreamResponse:
         return await self.put(f"segments/{segment_id}", data=data)
 

--- a/stream_chat/async_chat/segment.py
+++ b/stream_chat/async_chat/segment.py
@@ -28,29 +28,29 @@ class Segment(SegmentInterface):
         return state
 
     async def get(self) -> StreamResponse:
-        self.verify_segment_id()
+        super().verify_segment_id()
         return await self.client.get_segment(segment_id=self.segment_id)  # type: ignore
 
     async def update(self, data: SegmentUpdatableFields) -> StreamResponse:
-        self.verify_segment_id()
+        super().verify_segment_id()
         return await self.client.update_segment(  # type: ignore
             segment_id=self.segment_id, data=data
         )
 
     async def delete(self) -> StreamResponse:
-        self.verify_segment_id()
+        super().verify_segment_id()
         return await self.client.delete_segment(  # type: ignore
             segment_id=self.segment_id
         )
 
     async def target_exists(self, target_id: str) -> StreamResponse:
-        self.verify_segment_id()
+        super().verify_segment_id()
         return await self.client.segment_target_exists(  # type: ignore
             segment_id=self.segment_id, target_id=target_id
         )
 
     async def add_targets(self, target_ids: list) -> StreamResponse:
-        self.verify_segment_id()
+        super().verify_segment_id()
         return await self.client.add_segment_targets(  # type: ignore
             segment_id=self.segment_id, target_ids=target_ids
         )
@@ -61,7 +61,7 @@ class Segment(SegmentInterface):
         sort: Optional[List[SortParam]] = None,
         options: Optional[QuerySegmentTargetsOptions] = None,
     ) -> StreamResponse:
-        self.verify_segment_id()
+        super().verify_segment_id()
         return await self.client.query_segment_targets(  # type: ignore
             segment_id=self.segment_id,
             filter_conditions=filter_conditions,
@@ -70,14 +70,7 @@ class Segment(SegmentInterface):
         )
 
     async def remove_targets(self, target_ids: list) -> StreamResponse:
-        self.verify_segment_id()
+        super().verify_segment_id()
         return await self.client.remove_segment_targets(  # type: ignore
             segment_id=self.segment_id, target_ids=target_ids
         )
-
-    def verify_segment_id(self) -> None:
-        if not self.segment_id:
-            raise ValueError(
-                "Segment id is missing. Either create the segment using segment.create() "
-                "or set the id during instantiation - segment = Segment(segment_id=segment_id)"
-            )

--- a/stream_chat/async_chat/segment.py
+++ b/stream_chat/async_chat/segment.py
@@ -2,7 +2,11 @@ from typing import Dict, List, Optional
 
 from stream_chat.base.segment import SegmentInterface
 from stream_chat.types.base import SortParam
-from stream_chat.types.segment import QuerySegmentTargetsOptions, SegmentData
+from stream_chat.types.segment import (
+    QuerySegmentTargetsOptions,
+    SegmentData,
+    SegmentUpdatableFields,
+)
 from stream_chat.types.stream_response import StreamResponse
 
 
@@ -24,24 +28,29 @@ class Segment(SegmentInterface):
         return state
 
     async def get(self) -> StreamResponse:
+        self.verify_segment_id()
         return await self.client.get_segment(segment_id=self.segment_id)  # type: ignore
 
-    async def update(self, data: SegmentData) -> StreamResponse:
+    async def update(self, data: SegmentUpdatableFields) -> StreamResponse:
+        self.verify_segment_id()
         return await self.client.update_segment(  # type: ignore
             segment_id=self.segment_id, data=data
         )
 
     async def delete(self) -> StreamResponse:
+        self.verify_segment_id()
         return await self.client.delete_segment(  # type: ignore
             segment_id=self.segment_id
         )
 
     async def target_exists(self, target_id: str) -> StreamResponse:
+        self.verify_segment_id()
         return await self.client.segment_target_exists(  # type: ignore
             segment_id=self.segment_id, target_id=target_id
         )
 
     async def add_targets(self, target_ids: list) -> StreamResponse:
+        self.verify_segment_id()
         return await self.client.add_segment_targets(  # type: ignore
             segment_id=self.segment_id, target_ids=target_ids
         )
@@ -52,6 +61,7 @@ class Segment(SegmentInterface):
         sort: Optional[List[SortParam]] = None,
         options: Optional[QuerySegmentTargetsOptions] = None,
     ) -> StreamResponse:
+        self.verify_segment_id()
         return await self.client.query_segment_targets(  # type: ignore
             segment_id=self.segment_id,
             filter_conditions=filter_conditions,
@@ -60,6 +70,14 @@ class Segment(SegmentInterface):
         )
 
     async def remove_targets(self, target_ids: list) -> StreamResponse:
+        self.verify_segment_id()
         return await self.client.remove_segment_targets(  # type: ignore
             segment_id=self.segment_id, target_ids=target_ids
         )
+
+    def verify_segment_id(self) -> None:
+        if not self.segment_id:
+            raise ValueError(
+                "Segment id is missing. Either create the segment using segment.create() "
+                "or set the id during instantiation - segment = Segment(segment_id=segment_id)"
+            )

--- a/stream_chat/base/client.py
+++ b/stream_chat/base/client.py
@@ -14,6 +14,7 @@ from stream_chat.types.segment import (
     QuerySegmentTargetsOptions,
     SegmentData,
     SegmentType,
+    SegmentUpdatableFields,
 )
 
 if sys.version_info >= (3, 8):
@@ -982,7 +983,7 @@ class StreamChatInterface(abc.ABC):
 
     @abc.abstractmethod
     def update_segment(
-        self, segment_id: str, data: SegmentData
+        self, segment_id: str, data: SegmentUpdatableFields
     ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         """
         Update a segment by id

--- a/stream_chat/base/segment.py
+++ b/stream_chat/base/segment.py
@@ -7,6 +7,7 @@ from stream_chat.types.segment import (
     QuerySegmentTargetsOptions,
     SegmentData,
     SegmentType,
+    SegmentUpdatableFields,
 )
 from stream_chat.types.stream_response import StreamResponse
 
@@ -36,7 +37,7 @@ class SegmentInterface(abc.ABC):
 
     @abc.abstractmethod
     def update(
-        self, data: SegmentData
+        self, data: SegmentUpdatableFields
     ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         pass
 

--- a/stream_chat/base/segment.py
+++ b/stream_chat/base/segment.py
@@ -71,3 +71,10 @@ class SegmentInterface(abc.ABC):
         self, target_ids: List[str]
     ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
         pass
+
+    def verify_segment_id(self) -> None:
+        if not self.segment_id:
+            raise ValueError(
+                "Segment id is missing. Either create the segment using segment.create() "
+                "or set the id during instantiation - segment = Segment(segment_id=segment_id)"
+            )

--- a/stream_chat/client.py
+++ b/stream_chat/client.py
@@ -15,6 +15,7 @@ from stream_chat.types.segment import (
     QuerySegmentTargetsOptions,
     SegmentData,
     SegmentType,
+    SegmentUpdatableFields,
 )
 
 if sys.version_info >= (3, 8):
@@ -569,7 +570,9 @@ class StreamChat(StreamChatInterface):
             payload.update(cast(dict, options))
         return self.post("segments/query", data=payload)
 
-    def update_segment(self, segment_id: str, data: SegmentData) -> StreamResponse:
+    def update_segment(
+        self, segment_id: str, data: SegmentUpdatableFields
+    ) -> StreamResponse:
         return self.put(f"segments/{segment_id}", data=data)
 
     def delete_segment(self, segment_id: str) -> StreamResponse:

--- a/stream_chat/segment.py
+++ b/stream_chat/segment.py
@@ -28,27 +28,27 @@ class Segment(SegmentInterface):
         return state  # type: ignore
 
     def get(self) -> StreamResponse:
-        self.verify_segment_id()
+        super().verify_segment_id()
         return self.client.get_segment(segment_id=self.segment_id)  # type: ignore
 
     def update(self, data: SegmentUpdatableFields) -> StreamResponse:
-        self.verify_segment_id()
+        super().verify_segment_id()
         return self.client.update_segment(  # type: ignore
             segment_id=self.segment_id, data=data
         )
 
     def delete(self) -> StreamResponse:
-        self.verify_segment_id()
+        super().verify_segment_id()
         return self.client.delete_segment(segment_id=self.segment_id)  # type: ignore
 
     def target_exists(self, target_id: str) -> StreamResponse:
-        self.verify_segment_id()
+        super().verify_segment_id()
         return self.client.segment_target_exists(  # type: ignore
             segment_id=self.segment_id, target_id=target_id
         )
 
     def add_targets(self, target_ids: list) -> StreamResponse:
-        self.verify_segment_id()
+        super().verify_segment_id()
         return self.client.add_segment_targets(  # type: ignore
             segment_id=self.segment_id, target_ids=target_ids
         )
@@ -59,7 +59,7 @@ class Segment(SegmentInterface):
         sort: Optional[List[SortParam]] = None,
         options: Optional[QuerySegmentTargetsOptions] = None,
     ) -> StreamResponse:
-        self.verify_segment_id()
+        super().verify_segment_id()
         return self.client.query_segment_targets(  # type: ignore
             segment_id=self.segment_id,
             sort=sort,
@@ -68,14 +68,7 @@ class Segment(SegmentInterface):
         )
 
     def remove_targets(self, target_ids: list) -> StreamResponse:
-        self.verify_segment_id()
+        super().verify_segment_id()
         return self.client.remove_segment_targets(  # type: ignore
             segment_id=self.segment_id, target_ids=target_ids
         )
-
-    def verify_segment_id(self) -> None:
-        if not self.segment_id:
-            raise ValueError(
-                "Segment id is missing. Either create the segment using segment.create() "
-                "or set the id during instantiation - segment = Segment(segment_id=segment_id)"
-            )

--- a/stream_chat/segment.py
+++ b/stream_chat/segment.py
@@ -2,7 +2,11 @@ from typing import Dict, List, Optional
 
 from stream_chat.base.segment import SegmentInterface
 from stream_chat.types.base import SortParam
-from stream_chat.types.segment import QuerySegmentTargetsOptions, SegmentData
+from stream_chat.types.segment import (
+    QuerySegmentTargetsOptions,
+    SegmentData,
+    SegmentUpdatableFields,
+)
 from stream_chat.types.stream_response import StreamResponse
 
 
@@ -24,22 +28,27 @@ class Segment(SegmentInterface):
         return state  # type: ignore
 
     def get(self) -> StreamResponse:
+        self.verify_segment_id()
         return self.client.get_segment(segment_id=self.segment_id)  # type: ignore
 
-    def update(self, data: SegmentData) -> StreamResponse:
+    def update(self, data: SegmentUpdatableFields) -> StreamResponse:
+        self.verify_segment_id()
         return self.client.update_segment(  # type: ignore
             segment_id=self.segment_id, data=data
         )
 
     def delete(self) -> StreamResponse:
+        self.verify_segment_id()
         return self.client.delete_segment(segment_id=self.segment_id)  # type: ignore
 
     def target_exists(self, target_id: str) -> StreamResponse:
+        self.verify_segment_id()
         return self.client.segment_target_exists(  # type: ignore
             segment_id=self.segment_id, target_id=target_id
         )
 
     def add_targets(self, target_ids: list) -> StreamResponse:
+        self.verify_segment_id()
         return self.client.add_segment_targets(  # type: ignore
             segment_id=self.segment_id, target_ids=target_ids
         )
@@ -50,6 +59,7 @@ class Segment(SegmentInterface):
         sort: Optional[List[SortParam]] = None,
         options: Optional[QuerySegmentTargetsOptions] = None,
     ) -> StreamResponse:
+        self.verify_segment_id()
         return self.client.query_segment_targets(  # type: ignore
             segment_id=self.segment_id,
             sort=sort,
@@ -58,6 +68,14 @@ class Segment(SegmentInterface):
         )
 
     def remove_targets(self, target_ids: list) -> StreamResponse:
+        self.verify_segment_id()
         return self.client.remove_segment_targets(  # type: ignore
             segment_id=self.segment_id, target_ids=target_ids
         )
+
+    def verify_segment_id(self) -> None:
+        if not self.segment_id:
+            raise ValueError(
+                "Segment id is missing. Either create the segment using segment.create() "
+                "or set the id during instantiation - segment = Segment(segment_id=segment_id)"
+            )

--- a/stream_chat/types/segment.py
+++ b/stream_chat/types/segment.py
@@ -23,9 +23,9 @@ class SegmentType(Enum):
     USER = "user"
 
 
-class SegmentData(TypedDict, total=False):
+class SegmentUpdatableFields(TypedDict, total=False):
     """
-    Represents the data structure for a segment.
+    Represents the updatable data structure for a segment.
 
     Parameters:
         name: The name of the segment.
@@ -36,6 +36,19 @@ class SegmentData(TypedDict, total=False):
     name: Optional[str]
     description: Optional[str]
     filter: Optional[Dict]
+
+
+class SegmentData(SegmentUpdatableFields, total=False):
+    """
+    Represents the data structure for a segment.
+
+    Parameters:
+        all_users: Whether to target all users.
+        all_sender_channels: Whether to target all sender channels.
+    """
+
+    all_users: Optional[bool]
+    all_sender_channels: Optional[bool]
 
 
 class QuerySegmentsOptions(Pager, total=False):


### PR DESCRIPTION
Related ticket:
- https://stream-io.atlassian.net/browse/PBE-1383

Related PRs:
- https://github.com/GetStream/chat/pull/6066
- https://github.com/GetStream/stream-chat-js/pull/1258

## Description
This PR enables support for sending a campaign:
- to all users
- to all channels where the sender is a member. 

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
