### PR TITLE
feat: Add support for mark_unread msg or thread

### DIFF
--- a/stream_chat/async_chat/channel.py
+++ b/stream_chat/async_chat/channel.py
@@ -134,6 +134,10 @@ class Channel(ChannelInterface):
         payload = add_user_id(data, user_id)
         return await self.client.post(f"{self.url}/read", data=payload)
 
+    async def mark_unread(self, user_id: str, **data: Any) -> StreamResponse:
+        payload = add_user_id(data, user_id)
+        return await self.client.post(f"{self.url}/unread", data=payload)
+
     async def get_replies(self, parent_id: str, **options: Any) -> StreamResponse:
         return await self.client.get(f"messages/{parent_id}/replies", params=options)
 

--- a/stream_chat/base/channel.py
+++ b/stream_chat/base/channel.py
@@ -278,6 +278,20 @@ class ChannelInterface(abc.ABC):
         pass
 
     @abc.abstractmethod
+    def mark_unread(
+        self, user_id: str, **data: Any
+    ) -> Union[StreamResponse, Awaitable[StreamResponse]]:
+        """
+        Marks channel as unread from a specific message or thread, if thread_id is provided in data
+        a thread will be searched, otherwise a message.
+
+        :param user_id: the user ID for the event
+        :param data: additional data, ie {"message_id": last_message_id} or {"thread_id": thread_id}
+        :return: The server response
+        """
+        pass
+
+    @abc.abstractmethod
     def get_replies(
         self, parent_id: str, **options: Any
     ) -> Union[StreamResponse, Awaitable[StreamResponse]]:

--- a/stream_chat/channel.py
+++ b/stream_chat/channel.py
@@ -135,6 +135,10 @@ class Channel(ChannelInterface):
         payload = add_user_id(data, user_id)
         return self.client.post(f"{self.url}/read", data=payload)
 
+    def mark_unread(self, user_id: str, **data: Any) -> StreamResponse:
+        payload = add_user_id(data, user_id)
+        return self.client.post(f"{self.url}/unread", data=payload)
+
     def get_replies(self, parent_id: str, **options: Any) -> StreamResponse:
         return self.client.get(f"messages/{parent_id}/replies", params=options)
 

--- a/stream_chat/tests/async_chat/test_channel.py
+++ b/stream_chat/tests/async_chat/test_channel.py
@@ -169,6 +169,13 @@ class TestChannel:
         assert "event" in response
         assert response["event"]["type"] == "message.read"
 
+    async def test_mark_unread(self, channel: Channel, random_user: Dict):
+        msg = await channel.send_message({"text": "hi"}, random_user["id"])
+        response = await channel.mark_unread(
+            random_user["id"], message_id=msg["message"]["id"]
+        )
+        assert "duration" in response
+
     async def test_get_replies(self, channel: Channel, random_user: Dict):
         msg = await channel.send_message({"text": "hi"}, random_user["id"])
         response = await channel.get_replies(msg["message"]["id"])

--- a/stream_chat/tests/test_channel.py
+++ b/stream_chat/tests/test_channel.py
@@ -169,6 +169,12 @@ class TestChannel:
         assert "event" in response
         assert response["event"]["type"] == "message.read"
 
+    def test_mark_unread(self, channel: Channel, random_user: Dict):
+        msg_id = str(uuid.uuid4())
+        channel.send_message({"id": msg_id, "text": "helloworld"}, random_user["id"])
+        response = channel.mark_unread(random_user["id"], message_id=msg_id)
+        assert "duration" in response
+
     def test_get_messages(self, channel: Channel, random_user: Dict):
         msg_id = str(uuid.uuid4())
         channel.send_message({"id": msg_id, "text": "helloworld"}, random_user["id"])


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request

Add new api `mark_unread` for marking thread or message (`thread_id` // `message_id`)